### PR TITLE
Feature/build configuration param rawtype support

### DIFF
--- a/FluentTc.Tests/AcceptanceTests.cs
+++ b/FluentTc.Tests/AcceptanceTests.cs
@@ -150,7 +150,7 @@ namespace FluentTc.Tests
         }
 
         [Test]
-        public void SetBuildConfigurationParameters_ConfigurationName()
+        public void SetBuildConfigurationParameters_GivenParameterWithNullRawType_ConfigurationName()
         {
             // Arrange
             var teamCityCaller = A.Fake<TeamCityCaller>();
@@ -163,7 +163,27 @@ namespace FluentTc.Tests
             // Assert
             A.CallTo(
                 () =>
-                    teamCityCaller.PutFormat("newVal", HttpContentTypes.TextPlain, "/app/rest/buildTypes/{0}/parameters/{1}", A<object[]>.That.IsSameSequenceAs(new[] {"name:FluentTc", "name"})))
+                    teamCityCaller.PutFormat("{\"name\":\"name\",\"value\":\"newVal\",\"type\":null}",
+                    HttpContentTypes.ApplicationJson, "/app/rest/buildTypes/{0}/parameters/{1}", A<object[]>.That.IsSameSequenceAs(new[] {"name:FluentTc", "name"})))
+                        .MustHaveHappened(Repeated.Exactly.Once);
+        }
+
+        [Test]
+        public void SetBuildConfigurationParameters_GivenParameterWithRawType_ConfigurationName()
+        {
+            // Arrange
+            var teamCityCaller = A.Fake<TeamCityCaller>();
+
+            var connectedTc = new RemoteTc().Connect(_ => _.AsGuest(), teamCityCaller);
+
+            // Act
+            connectedTc.SetBuildConfigurationParameters(_ => _.Name("FluentTc"), p => p.Parameter("name", "newVal", "select data_1='lol' display='normal'"));
+
+            // Assert
+            A.CallTo(
+                () =>
+                    teamCityCaller.PutFormat("{\"name\":\"name\",\"value\":\"newVal\",\"type\":{\"rawValue\":\"select data_1='lol' display='normal'\"}}",
+                    HttpContentTypes.ApplicationJson, "/app/rest/buildTypes/{0}/parameters/{1}", A<object[]>.That.IsSameSequenceAs(new[] { "name:FluentTc", "name" })))
                         .MustHaveHappened(Repeated.Exactly.Once);
         }
 

--- a/FluentTc.Tests/AcceptanceTests.cs
+++ b/FluentTc.Tests/AcceptanceTests.cs
@@ -150,7 +150,7 @@ namespace FluentTc.Tests
         }
 
         [Test]
-        public void SetBuildConfigurationParameters_GivenParameterWithNullRawType_ConfigurationName()
+        public void SetBuildConfigurationParameters_GivenParameterWithoutRawType_ConfigurationName()
         {
             // Arrange
             var teamCityCaller = A.Fake<TeamCityCaller>();
@@ -705,7 +705,7 @@ namespace FluentTc.Tests
         }
 
         [Test]
-        public void SetProjectParameters_ById()
+        public void SetProjectParameters_GivenParameterWithoutRawType_ById()
         {
             // Arrange
             var teamCityCaller = CreateTeamCityCaller();
@@ -718,7 +718,27 @@ namespace FluentTc.Tests
             // Assert
             A.CallTo(
                 () =>
-                    teamCityCaller.Put("value1", HttpContentTypes.TextPlain, "/app/rest/projects/id:ProjectId/parameters/param1", string.Empty))
+                    teamCityCaller.Put("{\"name\":\"param1\",\"value\":\"value1\",\"type\":null}",
+                    HttpContentTypes.ApplicationJson, "/app/rest/projects/id:ProjectId/parameters/param1", string.Empty))
+                        .MustHaveHappened(Repeated.Exactly.Once);
+        }
+
+        [Test]
+        public void SetProjectParameters_GivenParameterWithRawType_ById()
+        {
+            // Arrange
+            var teamCityCaller = CreateTeamCityCaller();
+
+            var connectedTc = new RemoteTc().Connect(_ => _.AsGuest(), teamCityCaller);
+
+            // Act
+            connectedTc.SetProjectParameters(_ => _.Id("ProjectId"), __ => __.Parameter("param1", "value1", "rawType1"));
+
+            // Assert
+            A.CallTo(
+                () =>
+                    teamCityCaller.Put("{\"name\":\"param1\",\"value\":\"value1\",\"type\":{\"rawValue\":\"rawType1\"}}",
+                    HttpContentTypes.ApplicationJson, "/app/rest/projects/id:ProjectId/parameters/param1", string.Empty))
                         .MustHaveHappened(Repeated.Exactly.Once);
         }
 

--- a/FluentTc/Domain/Property.cs
+++ b/FluentTc/Domain/Property.cs
@@ -9,5 +9,6 @@ namespace FluentTc.Domain
 
         public string Name { get; set; }
         public string Value { get; set; }
+        public PropertyType Type { get; set; }
     }
 }

--- a/FluentTc/Domain/PropertyType.cs
+++ b/FluentTc/Domain/PropertyType.cs
@@ -1,0 +1,7 @@
+﻿namespace FluentTc.Domain
+{
+    public class PropertyType
+    {
+        public string RawValue { get; set; }
+    }
+}

--- a/FluentTc/Engine/BuildConfigurationRetriever.cs
+++ b/FluentTc/Engine/BuildConfigurationRetriever.cs
@@ -7,6 +7,7 @@ using EasyHttp.Infrastructure;
 using FluentTc.Domain;
 using FluentTc.Exceptions;
 using FluentTc.Locators;
+using JsonFx.Json;
 
 namespace FluentTc.Engine
 {
@@ -82,14 +83,15 @@ namespace FluentTc.Engine
                 m_BuildConfigurationHavingBuilderFactory.CreateBuildConfigurationHavingBuilder();
             having(buildConfigurationHavingBuilder);
 
+            var writer = new JsonWriter();
+
             BuildParameterValueBuilder buildParameterValueBuilder = new BuildParameterValueBuilder();
             parameters(buildParameterValueBuilder);
             buildParameterValueBuilder.GetParameters()
                 .ForEach(
                     p =>
-                        m_TeamCityCaller.PutFormat(p.Value, HttpContentTypes.TextPlain,
-                            "/app/rest/buildTypes/{0}/parameters/{1}", buildConfigurationHavingBuilder.GetLocator(),
-                            p.Name));
+                        m_TeamCityCaller.PutFormat(writer.Write(p), HttpContentTypes.ApplicationJson,
+                            "/app/rest/buildTypes/{0}/parameters/{1}", buildConfigurationHavingBuilder.GetLocator(), p.Name));
         }
     }
 }

--- a/FluentTc/Engine/BuildConfigurationRetriever.cs
+++ b/FluentTc/Engine/BuildConfigurationRetriever.cs
@@ -8,6 +8,8 @@ using FluentTc.Domain;
 using FluentTc.Exceptions;
 using FluentTc.Locators;
 using JsonFx.Json;
+using JsonFx.Serialization.Resolvers;
+using JsonFx.Serialization;
 
 namespace FluentTc.Engine
 {
@@ -83,7 +85,7 @@ namespace FluentTc.Engine
                 m_BuildConfigurationHavingBuilderFactory.CreateBuildConfigurationHavingBuilder();
             having(buildConfigurationHavingBuilder);
 
-            var writer = new JsonWriter();
+            var writer = new JsonWriter(new DataWriterSettings(new ConventionResolverStrategy(ConventionResolverStrategy.WordCasing.CamelCase)));
 
             BuildParameterValueBuilder buildParameterValueBuilder = new BuildParameterValueBuilder();
             parameters(buildParameterValueBuilder);

--- a/FluentTc/Engine/BuildConfigurationRunner.cs
+++ b/FluentTc/Engine/BuildConfigurationRunner.cs
@@ -66,7 +66,17 @@ namespace FluentTc.Engine
 
                 foreach (var property in properties)
                 {
-                    bodyBuilder.AppendFormat(@"<property name=""{0}"" value=""{1}""/>", property.Name, property.Value).AppendLine();
+                    bodyBuilder.AppendFormat(@"<property name=""{0}"" value=""{1}""", property.Name, property.Value);
+                    if (property.Type != null && !string.IsNullOrEmpty(property.Type.RawValue))
+                    {
+                        bodyBuilder.Append(">").AppendLine();
+                        bodyBuilder.AppendFormat(@"<type rawValue=""{0}""/>", property.Type.RawValue).AppendLine();
+                        bodyBuilder.Append("</property>").AppendLine();
+                    }
+                    else
+                    {
+                        bodyBuilder.Append("/>").AppendLine();
+                    }
                 }
 
                 bodyBuilder.Append(@"</properties>").AppendLine();

--- a/FluentTc/Engine/ProjectPropertySetter.cs
+++ b/FluentTc/Engine/ProjectPropertySetter.cs
@@ -1,6 +1,9 @@
 using System;
 using EasyHttp.Http;
 using FluentTc.Locators;
+using JsonFx.Serialization.Resolvers;
+using JsonFx.Serialization;
+using JsonFx.Json;
 
 namespace FluentTc.Engine
 {
@@ -27,11 +30,13 @@ namespace FluentTc.Engine
             having(buildConfigurationHavingBuilder);
             var projectLocator = buildConfigurationHavingBuilder.GetLocator();
 
+            var writer = new JsonWriter(new DataWriterSettings(new ConventionResolverStrategy(ConventionResolverStrategy.WordCasing.CamelCase)));
+
             BuildParameterValueBuilder buildParameterValueBuilder = new BuildParameterValueBuilder();
             parameters(buildParameterValueBuilder);
 
             buildParameterValueBuilder.GetParameters()
-                .ForEach(p => m_TeamCityCaller.PutFormat(p.Value, HttpContentTypes.TextPlain,
+                .ForEach(p => m_TeamCityCaller.PutFormat(writer.Write(p), HttpContentTypes.ApplicationJson,
                         "/app/rest/projects/{0}/parameters/{1}", projectLocator, p.Name));
         }
 

--- a/FluentTc/FluentTc.csproj
+++ b/FluentTc/FluentTc.csproj
@@ -98,6 +98,7 @@
     <Compile Include="Domain\ProjectWrapper.cs" />
     <Compile Include="Domain\Properties.cs" />
     <Compile Include="Domain\Property.cs" />
+    <Compile Include="Domain\PropertyType.cs" />
     <Compile Include="Domain\ResolutionWrapper.cs" />
     <Compile Include="Domain\Role.cs" />
     <Compile Include="Domain\RoleWrapper.cs" />

--- a/FluentTc/Locators/BuildParameterValueBuilder.cs
+++ b/FluentTc/Locators/BuildParameterValueBuilder.cs
@@ -5,12 +5,19 @@ namespace FluentTc.Locators
 {
     public interface IBuildParameterValueBuilder
     {
+        IBuildParameterValueBuilder Parameter(string name, string value);
         IBuildParameterValueBuilder Parameter(string name, string value, string rawValue);
     }
 
     public class BuildParameterValueBuilder : IBuildParameterValueBuilder
     {
         readonly List<Property> m_Properties = new List<Property>();
+
+        public IBuildParameterValueBuilder Parameter(string name, string value)
+        {
+            m_Properties.Add(new Property { Name = name, Value = value, Type = null });
+            return this;
+        }
 
         public IBuildParameterValueBuilder Parameter(string name, string value, string rawValue)
         {

--- a/FluentTc/Locators/BuildParameterValueBuilder.cs
+++ b/FluentTc/Locators/BuildParameterValueBuilder.cs
@@ -5,16 +5,16 @@ namespace FluentTc.Locators
 {
     public interface IBuildParameterValueBuilder
     {
-        IBuildParameterValueBuilder Parameter(string name, string value);
+        IBuildParameterValueBuilder Parameter(string name, string value, string rawValue);
     }
 
     public class BuildParameterValueBuilder : IBuildParameterValueBuilder
     {
         readonly List<Property> m_Properties = new List<Property>();
 
-        public IBuildParameterValueBuilder Parameter(string name, string value)
+        public IBuildParameterValueBuilder Parameter(string name, string value, string rawValue)
         {
-            m_Properties.Add(new Property { Name = name, Value = value});
+            m_Properties.Add(new Property { Name = name, Value = value, Type = new PropertyType { RawValue = rawValue } });
             return this;
         }
 


### PR DESCRIPTION
TeamCity 9.x allows for parameter typing, which is done by providing a special value to a special object (called Type) inside of the parameter object. Theese changes allow to support that and they worked for my case (needed select list