### PR TITLE
Develop

### DIFF
--- a/FluentTc.Samples/Program.cs
+++ b/FluentTc.Samples/Program.cs
@@ -7,14 +7,15 @@ namespace FluentTc.Samples
 {
     internal static class Program
     {
-        private const string TeamCityHost = "";
-        private static readonly string Username = "";
-        private static readonly string Password = "";
+        private const string TeamCityHost = "tc";
+        private static readonly string Username = "buser";
+        private static readonly string Password = "qaz$9512";
 
         private static void Main(string[] args)
         {
             #region RemoteTc
 
+            //GetBuildConfigurationParameters();
             GetLastSuccessfulBuildsForEachConfigurationWithChanges("Trunk_Ci_FastCi");
 
             PrintEnabledAuthorizedDisconnectedAgents();
@@ -45,6 +46,13 @@ namespace FluentTc.Samples
             new RemoteTc()
                 .Connect(_ => _.ToHost(TeamCityHost).AsUser(Username, Password))
                 .DeleteBuildConfigurationParameter(_ => _.Id("buildConfigId"), __ => __.ParameterName("parameter.name"));
+        }
+
+        private static void GetBuildConfigurationParameters()
+        {
+            var buildConfiguration = new RemoteTc()
+                .Connect(_ => _.ToHost(TeamCityHost).AsUser(Username, Password))
+                .GetBuildConfiguration(_ => _.Id("Trunk_Green_Ci_Compile"));
         }
 
         private static void DeleteProjectParameter()

--- a/FluentTc.Samples/Program.cs
+++ b/FluentTc.Samples/Program.cs
@@ -7,15 +7,15 @@ namespace FluentTc.Samples
 {
     internal static class Program
     {
-        private const string TeamCityHost = "tc";
-        private static readonly string Username = "buser";
-        private static readonly string Password = "qaz$9512";
+        private const string TeamCityHost = "";
+        private static readonly string Username = "";
+        private static readonly string Password = "";
 
         private static void Main(string[] args)
         {
             #region RemoteTc
 
-            //GetBuildConfigurationParameters();
+            GetBuildConfigurationParameters();
             GetLastSuccessfulBuildsForEachConfigurationWithChanges("Trunk_Ci_FastCi");
 
             PrintEnabledAuthorizedDisconnectedAgents();

--- a/FluentTc.Tests/AcceptanceTests.cs
+++ b/FluentTc.Tests/AcceptanceTests.cs
@@ -178,7 +178,9 @@ namespace FluentTc.Tests
             var connectedTc = new RemoteTc().Connect(_ => _.AsGuest(), teamCityCaller);
 
             // Act
-            connectedTc.SetBuildConfigurationParameters(_ => _.Name("FluentTc"), p => p.Parameter("name", "newVal", "select data_1='lol' display='normal'"));
+            connectedTc.SetBuildConfigurationParameters(
+                _ => _.Name("FluentTc"), 
+                p => p.Parameter("name", "newVal", "select data_1='lol' display='normal'"));
 
             // Assert
             A.CallTo(

--- a/FluentTc.Tests/Engine/BuildModelToBuildConverterTests.cs
+++ b/FluentTc.Tests/Engine/BuildModelToBuildConverterTests.cs
@@ -72,5 +72,26 @@ namespace FluentTc.Tests.Engine
             builds.Single().Status.Should().Be(BuildStatus.Success);
             builds.Single().BuildConfiguration.Id.Should().Be("bt2");
         }
+
+        [Test]
+        public void ConvertToBuilds_StatusIsNull_StatusIsNull()
+        {
+            var buildModelToBuildConverter = new BuildModelToBuildConverter();
+            var buildWrapper = new BuildWrapper
+            {
+                Build = new List<BuildModel> {new BuildModel
+                {
+                    Status = null,
+                    BuildType = new BuildConfiguration { Id = "bt2"},
+                    BuildTypeId = "WRONG"
+                }},
+                Count = "1"
+            };
+            var builds = buildModelToBuildConverter.ConvertToBuilds(buildWrapper);
+
+            // Assert
+            builds.Single().Status.HasValue.Should().BeFalse();
+            builds.Single().BuildConfiguration.Id.Should().Be("bt2");
+        }
     }
 }

--- a/FluentTc/Domain/Build.cs
+++ b/FluentTc/Domain/Build.cs
@@ -8,7 +8,7 @@ namespace FluentTc.Domain
     {
         long Id { get; }
         string Number { get; }
-        BuildStatus Status { get; }
+        BuildStatus? Status { get; }
         DateTime StartDate { get; }
         DateTime FinishDate { get; }
         DateTime QueuedDate { get; }
@@ -30,10 +30,10 @@ namespace FluentTc.Domain
         private readonly string m_Number;
         private readonly DateTime m_QueuedDate;
         private readonly DateTime m_StartDate;
-        private readonly BuildStatus m_Status;
+        private readonly BuildStatus? m_Status;
         private readonly string m_WebUrl;
 
-        public Build(long id, string number, BuildStatus status, DateTime startDate, DateTime finishDate,
+        public Build(long id, string number, BuildStatus? status, DateTime startDate, DateTime finishDate,
             DateTime queuedDate, BuildConfiguration buildConfiguration, Agent agent, List<Change> changes, string webUrl)
         {
             m_Id = id;
@@ -58,7 +58,7 @@ namespace FluentTc.Domain
             get { return m_Number; }
         }
 
-        public BuildStatus Status
+        public BuildStatus? Status
         {
             get { return m_Status; }
         }

--- a/FluentTc/Engine/BuildModelToBuildConverter.cs
+++ b/FluentTc/Engine/BuildModelToBuildConverter.cs
@@ -35,8 +35,9 @@ namespace FluentTc.Engine
                 buildModel.Agent, changes, buildModel.WebUrl);
         }
 
-        private static BuildStatus ConvertBuildStatus(BuildModel buildModel)
+        private static BuildStatus? ConvertBuildStatus(BuildModel buildModel)
         {
+            if (string.IsNullOrEmpty(buildModel.Status)) return null;
             return (BuildStatus)Enum.Parse(typeof(BuildStatus), UppercaseFirst(buildModel.Status));
         }
 


### PR DESCRIPTION
### Issue details
IBuild.Status was changed to nullable in order to support queued builds, which have no Status

### Checklist
- [x ] All unit tests passed on build server
- [] Acceptance test(s) covers new/modified functionality 
- [x ] Code coverage is at least the same or higher
- [x] Breaking change in public API

# Example of using new/modified functionality

```C#
// _Please provide necessary steps for reproduction of this issue_.
[Test]
public void Test_To_Reproduce_The_Issue()
{
    var builds = connectedTc.GetBuildsQueue();
}
```
