### PR TITLE
SetBuildConfigurationParameters was improved by @sokolovsv90 and it supports now builder for parameter type

### DIFF
--- a/FluentTc.Tests/AcceptanceTests.cs
+++ b/FluentTc.Tests/AcceptanceTests.cs
@@ -178,9 +178,8 @@ namespace FluentTc.Tests
             var connectedTc = new RemoteTc().Connect(_ => _.AsGuest(), teamCityCaller);
 
             // Act
-            connectedTc.SetBuildConfigurationParameters(
-                _ => _.Name("FluentTc"), 
-                p => p.Parameter("name", "newVal", "select data_1='lol' display='normal'"));
+            connectedTc.SetBuildConfigurationParameters(_ => _.Name("FluentTc"), 
+                p => p.Parameter("name", "newVal", t => t.AsSelectList(s => s.Value("lol"))));
 
             // Assert
             A.CallTo(
@@ -735,12 +734,12 @@ namespace FluentTc.Tests
             var connectedTc = new RemoteTc().Connect(_ => _.AsGuest(), teamCityCaller);
 
             // Act
-            connectedTc.SetProjectParameters(_ => _.Id("ProjectId"), __ => __.Parameter("param1", "value1", "rawType1"));
+            connectedTc.SetProjectParameters(_ => _.Id("ProjectId"), __ => __.Parameter("param1", "value1", t => t.AsSelectList(s => s.Value("item1"))));
 
             // Assert
             A.CallTo(
                 () =>
-                    teamCityCaller.Put("{\"name\":\"param1\",\"value\":\"value1\",\"type\":{\"rawValue\":\"rawType1\"}}",
+                    teamCityCaller.Put("{\"name\":\"param1\",\"value\":\"value1\",\"type\":{\"rawValue\":\"select data_1='item1' display='normal'\"}}",
                     HttpContentTypes.ApplicationJson, "/app/rest/projects/id:ProjectId/parameters/param1", string.Empty))
                         .MustHaveHappened(Repeated.Exactly.Once);
         }

--- a/FluentTc.Tests/Engine/BuildStatisticConverterTests.cs
+++ b/FluentTc.Tests/Engine/BuildStatisticConverterTests.cs
@@ -1,0 +1,45 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using FluentTc.Domain;
+using FluentTc.Engine;
+using NUnit.Framework;
+
+namespace FluentTc.Tests.Engine
+{
+    [TestFixture]
+    public class BuildStatisticConverterTests
+    {
+        [Test]
+        public void Convert_EmptyModel_EmptyList()
+        {
+            // Arrange
+            var buildStatisticConverter = new BuildStatisticConverter();
+
+            // Act
+            var buildStatistics = buildStatisticConverter.Convert(new BuildStatisticsModel());
+
+            // Assert
+            buildStatistics.Should().BeEmpty();
+        }
+
+        [Test]
+        public void Convert_ModelWithOneProperty_OneStatistic()
+        {
+            // Arrange
+            var buildStatisticConverter = new BuildStatisticConverter();
+
+            // Act
+            var buildStatistics = buildStatisticConverter.Convert(new BuildStatisticsModel
+            {
+                Count = "1",
+                Property = new List<Property> {new Property {Name = "PropName", Value = "PropVal"}}
+            });
+
+            // Assert
+            buildStatistics.Count.Should().Be(1);
+            buildStatistics.Single().Name.Should().Be("PropName");
+            buildStatistics.Single().Value.Should().Be("PropVal");
+        }
+    }
+}

--- a/FluentTc.Tests/Engine/BuildStatisticsRetrieverTests.cs
+++ b/FluentTc.Tests/Engine/BuildStatisticsRetrieverTests.cs
@@ -4,42 +4,49 @@ using FluentTc.Engine;
 using FluentTc.Locators;
 using NUnit.Framework;
 using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
 
 namespace FluentTc.Tests.Engine
 {
     [TestFixture]
-    public class StatisticsRetrieverTests
+    public class BuildStatisticsRetrieverTests
     {
         [Test]
         public void GetStatistics_ByBuild_ShouldReturnZeroResults()
         {
             // Arrange
             var teamCityCaller = A.Fake<ITeamCityCaller>();
+            var buildStatisticsModel = new BuildStatisticsModel { Count = "0", Property = { } };
             A.CallTo(
                () =>
-                   teamCityCaller.GetFormat<BuildStatistics>(
+                   teamCityCaller.GetFormat<BuildStatisticsModel>(
                        "/app/rest/builds/{0}/statistics",
                        A<object[]>._))
-               .Returns(new BuildStatistics { Count = "0", Property = { } });
+               .Returns(buildStatisticsModel);
 
             var buildHavingBuilder = A.Fake<BuildHavingBuilder>();
             A.CallTo(() => buildHavingBuilder.GetLocator()).Returns("buildId:123");
             var buildHavingBuilderFactory = A.Fake<IBuildHavingBuilderFactory>();
             A.CallTo(() => buildHavingBuilderFactory.CreateBuildHavingBuilder()).Returns(buildHavingBuilder);
 
-            var statisticsRetriever = new BuildStatisticsRetriever(teamCityCaller, buildHavingBuilderFactory);
+            var buildStatisticConverter = A.Fake<IBuildStatisticConverter>();
+            A.CallTo(() => buildStatisticConverter.Convert(buildStatisticsModel)).Returns(new List<IBuildStatistic>());
+
+            var statisticsRetriever = new BuildStatisticsRetriever(teamCityCaller, buildHavingBuilderFactory, buildStatisticConverter);
 
             // Act
-            var statistics = statisticsRetriever.GetStatistics(_ => _.Id(123));
+            var statistics = statisticsRetriever.GetBuildStatistics(_ => _.Id(123));
 
             // Assert
             A.CallTo(
                 () =>
-                    teamCityCaller.GetFormat<BuildStatistics>(
+                    teamCityCaller.GetFormat<BuildStatisticsModel>(
                        "/app/rest/builds/{0}/statistics",
                         A<object[]>.That.IsSameSequenceAs(new object[] { "buildId:123" })))
                 .MustHaveHappened(Repeated.Exactly.Once);
-            Assert.AreEqual("0", statistics.Count);
+
+            statistics.Should().BeEmpty();
         }
 
         [Test]
@@ -50,35 +57,45 @@ namespace FluentTc.Tests.Engine
                         new Property { Name = "MockProperty1", Value = "MockValue1" }, 
                         new Property { Name = "MockProperty2", Value = "MockValue2" } 
             };
-            var mockStatistics = new BuildStatistics { Count = "2", Property = mockPropertyList };
+            var buildStatisticsModel = new BuildStatisticsModel { Count = "2", Property = mockPropertyList };
             
             var teamCityCaller = A.Fake<ITeamCityCaller>();
             A.CallTo(
                () =>
-                   teamCityCaller.GetFormat<BuildStatistics>(
+                   teamCityCaller.GetFormat<BuildStatisticsModel>(
                        "/app/rest/builds/{0}/statistics",
                        A<object[]>._))
-               .Returns(mockStatistics);
+               .Returns(buildStatisticsModel);
 
             var buildHavingBuilder = A.Fake<BuildHavingBuilder>();
             A.CallTo(() => buildHavingBuilder.GetLocator()).Returns("buildId:123");
             var buildHavingBuilderFactory = A.Fake<IBuildHavingBuilderFactory>();
             A.CallTo(() => buildHavingBuilderFactory.CreateBuildHavingBuilder()).Returns(buildHavingBuilder);
 
-            var statisticsRetriever = new BuildStatisticsRetriever(teamCityCaller, buildHavingBuilderFactory);
+            var buildStatisticConverter = A.Fake<IBuildStatisticConverter>();
+            A.CallTo(() => buildStatisticConverter.Convert(buildStatisticsModel)).Returns(new List<IBuildStatistic>()
+            {
+                new BuildStatistic("MockProperty1", "MockValue1"),
+                new BuildStatistic("MockProperty2", "MockValue2")
+            });
+
+            var statisticsRetriever = new BuildStatisticsRetriever(teamCityCaller, buildHavingBuilderFactory, buildStatisticConverter);
 
             // Act
-            var statistics = statisticsRetriever.GetStatistics(_ => _.Id(1));
+            var statistics = statisticsRetriever.GetBuildStatistics(_ => _.Id(1));
 
             // Assert
             A.CallTo(
                 () =>
-                    teamCityCaller.GetFormat<BuildStatistics>(
+                    teamCityCaller.GetFormat<BuildStatisticsModel>(
                        "/app/rest/builds/{0}/statistics",
                         A<object[]>.That.IsSameSequenceAs(new object[] { "buildId:123" })))
                 .MustHaveHappened(Repeated.Exactly.Once);
-            Assert.AreEqual("MockValue1", statistics.Property[0].Value);
-            Assert.AreEqual("MockValue2", statistics.Property[1].Value);
+            statistics.Count.Should().Be(2);
+            statistics.First().Name.Should().Be("MockProperty1");
+            statistics.First().Value.Should().Be("MockValue1");
+            statistics.Last().Name.Should().Be("MockProperty2");
+            statistics.Last().Value.Should().Be("MockValue2");
         }
     }
 }

--- a/FluentTc.Tests/Engine/UniversalTypeConverterTests.cs
+++ b/FluentTc.Tests/Engine/UniversalTypeConverterTests.cs
@@ -1,4 +1,5 @@
-﻿using FluentAssertions;
+﻿using System;
+using FluentAssertions;
 using FluentTc.Engine;
 using NUnit.Framework;
 
@@ -21,6 +22,31 @@ namespace FluentTc.Tests.Engine
             var value = UniversalTypeConverter.StringToType<bool>("true");
 
             value.Should().BeTrue();
+        }
+
+        [Test]
+        public void StringToType_BooleanStringEmpty_FormatExceptionThrown()
+        {
+            Action action = () => UniversalTypeConverter.StringToType<bool>("");
+
+            action.ShouldThrow<FormatException>().WithMessage("String was not recognized as a valid Boolean.");
+        }
+
+        [Test]
+        public void StringToType_NullableBooleanStringEmpty_HasNoValue()
+        {
+            var value = UniversalTypeConverter.StringToType<bool?>("");
+
+            value.HasValue.Should().BeFalse();
+        }
+
+        [Test]
+        public void StringToType_NullableBooleanTrue_True()
+        {
+            var value = UniversalTypeConverter.StringToType<bool?>("true");
+
+            value.HasValue.Should().BeTrue();
+            value.Value.Should().BeTrue();
         }
     }
 }

--- a/FluentTc.Tests/FluentTc.Tests.csproj
+++ b/FluentTc.Tests/FluentTc.Tests.csproj
@@ -108,6 +108,7 @@
     <Compile Include="Engine\BuildModelToBuildConverterTests.cs" />
     <Compile Include="Engine\BuildParametersTests.cs" />
     <Compile Include="Engine\BuildQueueRemoverTests.cs" />
+    <Compile Include="Engine\BuildStatisticConverterTests.cs" />
     <Compile Include="Engine\ChangesRetrieverTests.cs" />
     <Compile Include="Engine\ChangedFilesParserTests.cs" />
     <Compile Include="Engine\NewProjectDetailsBuilderTests.cs" />

--- a/FluentTc.Tests/FluentTc.Tests.csproj
+++ b/FluentTc.Tests/FluentTc.Tests.csproj
@@ -124,6 +124,7 @@
     <Compile Include="Locators\BuildConfigurationHavingBuilderTests.cs" />
     <Compile Include="Locators\BuildHavingBuilderTests.cs" />
     <Compile Include="Locators\BuildIncludeBuilderTests.cs" />
+    <Compile Include="Locators\BuildParameterTypeBuilderFormatTests.cs" />
     <Compile Include="Locators\BuildProjectHavingBuilderTests.cs" />
     <Compile Include="Locators\BuildQueueIdHavingBuilderTests.cs" />
     <Compile Include="Locators\ChangesHavingBuilderTests.cs" />

--- a/FluentTc.Tests/Locators/BuildParameterTypeBuilderFormatTests.cs
+++ b/FluentTc.Tests/Locators/BuildParameterTypeBuilderFormatTests.cs
@@ -1,0 +1,200 @@
+﻿using System;
+using System.Collections.Generic;
+using FluentTc.Locators;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace FluentTc.Tests.Locators
+{
+    [TestFixture]
+    public class BuildParameterTypeBuilderFormatTests
+    {
+        [TestCase(null, null, "checkbox")]
+        [TestCase(null, "kek", "checkbox uncheckedValue='kek'")]
+        [TestCase("lol", null, "checkbox checkedValue='lol'")]
+        [TestCase("lol", "kek", "checkbox checkedValue='lol' uncheckedValue='kek'")]
+        public void BuildParameterCheckboxTypeBuilder_FormatTest(string checkedValue, string uncheckedValue, string expected)
+        {
+            // Arrange
+            var testObject = new BuildParameterCheckboxTypeBuilder();
+            if (checkedValue != null)
+                testObject.WithCheckedValue(checkedValue);
+            if (uncheckedValue != null)
+                testObject.WithUncheckedValue(uncheckedValue);
+
+            // Act
+            var result = testObject.Build();
+
+            // Assert
+            result.Should().Be(expected);
+        }
+
+        [TestCase(0, null, null, "text validationMode='any'")]
+        [TestCase(0, "kek", null, "text validationMode='any'")]
+        [TestCase(0, null, "lol", "text validationMode='any'")]
+        [TestCase(0, "kek", "lol", "text validationMode='any'")]
+        [TestCase(1, null, null, "text validationMode='not_empty'")]
+        [TestCase(1, "kek", null, "text validationMode='not_empty'")]
+        [TestCase(1, null, "lol", "text validationMode='not_empty'")]
+        [TestCase(1, "kek", "lol", "text validationMode='not_empty'")]
+        [TestCase(2, null, null, "text validationMode='regex'")]
+        [TestCase(2, "kek", null, "text validationMode='regex' regexp='kek'")]
+        [TestCase(2, null, "lol", "text validationMode='regex' validationMessage='lol'")]
+        [TestCase(2, "kek", "lol", "text validationMode='regex' regexp='kek' validationMessage='lol'")]
+        public void BuildParameterTextTypeBuilder_FormatTest(int validation, string regexp, string validationMessage, string expected)
+        {
+            // Arrange
+            var testObject = new BuildParameterTextTypeBuilder();
+            var validationMap = new Dictionary<int, Action>
+            {
+                {0, () => testObject.AsAny()},
+                {1, () => testObject.AsNotEmpty()},
+                {2, () => testObject.AsRegex(regexp, validationMessage)}
+            };
+            if (!validationMap.ContainsKey(validation))
+                Assert.Inconclusive("Wrong 'validation' argument value passed");
+            validationMap[validation]();
+
+            // Act
+            var result = testObject.Build();
+
+            // Assert
+            result.Should().Be(expected);
+        }
+
+        [TestCase(null, null, null, null, null, "")]
+        [TestCase(true, null, null, null, null, "")]
+        [TestCase(false, null, null, null, null, "")]
+        [TestCase(null, "||", null, null, null, "")]
+        [TestCase(true, "||", null, null, null, "")]
+        [TestCase(false, "||", null, null, null, "")]
+        [TestCase(null, null, "uv", null, null, "select data_1='uv'")]
+        [TestCase(true, null, "uv", null, null, "select multiple='true' data_1='uv'")]
+        [TestCase(false, null, "uv", null, null, "select data_1='uv'")]
+        [TestCase(null, "||", "uv", null, null, "select data_1='uv'")]
+        [TestCase(true, "||", "uv", null, null, "select multiple='true' valueSeparator='||' data_1='uv'")]
+        [TestCase(false, "||", "uv", null, null, "select data_1='uv'")]
+        [TestCase(null, null, null, "l", null, "")]
+        [TestCase(true, null, null, "l", null, "")]
+        [TestCase(false, null, null, "l", null, "")]
+        [TestCase(null, "||", null, "l", null, "")]
+        [TestCase(true, "||", null, "l", null, "")]
+        [TestCase(false, "||", null, "l", null, "")]
+        [TestCase(null, null, "uv", "l", null, "select data_1='uv'")]
+        [TestCase(true, null, "uv", "l", null, "select multiple='true' data_1='uv'")]
+        [TestCase(false, null, "uv", "l", null, "select data_1='uv'")]
+        [TestCase(null, "||", "uv", "l", null, "select data_1='uv'")]
+        [TestCase(true, "||", "uv", "l", null, "select multiple='true' valueSeparator='||' data_1='uv'")]
+        [TestCase(false, "||", "uv", "l", null, "select data_1='uv'")]
+        [TestCase(null, null, null, null, "v", "select data_1='v'")]
+        [TestCase(true, null, null, null, "v", "select multiple='true' data_1='v'")]
+        [TestCase(false, null, null, null, "v", "select data_1='v'")]
+        [TestCase(null, "||", null, null, "v", "select data_1='v'")]
+        [TestCase(true, "||", null, null, "v", "select multiple='true' valueSeparator='||' data_1='v'")]
+        [TestCase(false, "||", null, null, "v", "select data_1='v'")]
+        [TestCase(null, null, "uv", null, "v", "select data_1='uv' data_2='v'")]
+        [TestCase(true, null, "uv", null, "v", "select multiple='true' data_1='uv' data_2='v'")]
+        [TestCase(false, null, "uv", null, "v", "select data_1='uv' data_2='v'")]
+        [TestCase(null, "||", "uv", null, "v", "select data_1='uv' data_2='v'")]
+        [TestCase(true, "||", "uv", null, "v", "select multiple='true' valueSeparator='||' data_1='uv' data_2='v'")]
+        [TestCase(false, "||", "uv", null, "v", "select data_1='uv' data_2='v'")]
+        [TestCase(null, null, null, "l", "v", "select label_1='l' data_1='v'")]
+        [TestCase(true, null, null, "l", "v", "select multiple='true' label_1='l' data_1='v'")]
+        [TestCase(false, null, null, "l", "v", "select label_1='l' data_1='v'")]
+        [TestCase(null, "||", null, "l", "v", "select label_1='l' data_1='v'")]
+        [TestCase(true, "||", null, "l", "v", "select multiple='true' valueSeparator='||' label_1='l' data_1='v'")]
+        [TestCase(false, "||", null, "l", "v", "select label_1='l' data_1='v'")]
+        [TestCase(null, null, "uv", "l", "v", "select data_1='uv' label_2='l' data_2='v'")]
+        [TestCase(true, null, "uv", "l", "v", "select multiple='true' data_1='uv' label_2='l' data_2='v'")]
+        [TestCase(false, null, "uv", "l", "v", "select data_1='uv' label_2='l' data_2='v'")]
+        [TestCase(null, "||", "uv", "l", "v", "select data_1='uv' label_2='l' data_2='v'")]
+        [TestCase(true, "||", "uv", "l", "v", "select multiple='true' valueSeparator='||' data_1='uv' label_2='l' data_2='v'")]
+        [TestCase(false, "||", "uv", "l", "v", "select data_1='uv' label_2='l' data_2='v'")]
+        public void BuildParameterSelectListTypeBuilder_FormatTest(bool? allowMultiple, string separator, string unlabeledValue, string label, string value, string expected)
+        {
+            // Arrange
+            var testObject = new BuildParameterSelectListTypeBuilder();
+
+            if (allowMultiple != null)
+                testObject.AllowMultiple(allowMultiple.Value);
+            if (separator != null)
+                testObject.WithSeparator(separator);
+            if (unlabeledValue != null)
+                testObject.Value(unlabeledValue);
+            if (value != null)
+                testObject.LabeledValue(label, value);
+
+            // Act
+            var result = testObject.Build();
+
+            // Assert
+            result.Should().Be(expected);
+        }
+
+        [TestCase(0, 0, null, null, "")]
+        [TestCase(1, 0, null, null, "password display='normal'")]
+        [TestCase(0, 1, null, null, "")]
+        [TestCase(1, 1, null, null, "password display='normal'")]
+        [TestCase(0, 2, null, null, "")]
+        [TestCase(1, 2, null, null, "password display='prompt'")]
+        [TestCase(0, 3, null, null, "")]
+        [TestCase(1, 3, null, null, "password display='hidden'")]
+        [TestCase(0, 0, "lol", null, "")]
+        [TestCase(1, 0, "lol", null, "password label='lol' display='normal'")]
+        [TestCase(0, 1, "lol", null, "")]
+        [TestCase(1, 1, "lol", null, "password label='lol' display='normal'")]
+        [TestCase(0, 2, "lol", null, "")]
+        [TestCase(1, 2, "lol", null, "password label='lol' display='prompt'")]
+        [TestCase(0, 3, "lol", null, "")]
+        [TestCase(1, 3, "lol", null, "password label='lol' display='hidden'")]
+        [TestCase(0, 0, null, "kek", "")]
+        [TestCase(1, 0, null, "kek", "password description='kek' display='normal'")]
+        [TestCase(0, 1, null, "kek", "")]
+        [TestCase(1, 1, null, "kek", "password description='kek' display='normal'")]
+        [TestCase(0, 2, null, "kek", "")]
+        [TestCase(1, 2, null, "kek", "password description='kek' display='prompt'")]
+        [TestCase(0, 3, null, "kek", "")]
+        [TestCase(1, 3, null, "kek", "password description='kek' display='hidden'")]
+        [TestCase(0, 0, "lol", "kek", "")]
+        [TestCase(1, 0, "lol", "kek", "password label='lol' description='kek' display='normal'")]
+        [TestCase(0, 1, "lol", "kek", "")]
+        [TestCase(1, 1, "lol", "kek", "password label='lol' description='kek' display='normal'")]
+        [TestCase(0, 2, "lol", "kek", "")]
+        [TestCase(1, 2, "lol", "kek", "password label='lol' description='kek' display='prompt'")]
+        [TestCase(0, 3, "lol", "kek", "")]
+        [TestCase(1, 3, "lol", "kek", "password label='lol' description='kek' display='hidden'")]
+        public void BuildParameterTypeBuilder_FormatTest(int type, int display, string label, string description, string expected)
+        {
+            // Arrange
+            var testObject = new BuildParameterTypeBuilder();
+            var typeMap = new Dictionary<int, Action>
+            {
+                {0, () => { }},
+                {1, () => testObject.AsPassword()}
+            };
+            if (!typeMap.ContainsKey(type))
+                Assert.Inconclusive("Wrong 'type' argument value passed");
+            typeMap[type]();
+            var displayMap = new Dictionary<int, Action>
+            {
+                {0, () => { }},
+                {1, () => testObject.WithDisplayNormal()},
+                {2, () => testObject.WithDisplayPrompt()},
+                {3, () => testObject.WithDisplayHidden()}
+            };
+            if (!displayMap.ContainsKey(display))
+                Assert.Inconclusive("Wrong 'display' argument value passed");
+            displayMap[display]();
+            if (label != null)
+                testObject.WithLabel(label);
+            if (description != null)
+                testObject.WithDescription(description);
+
+            // Act
+            var result = testObject.Build();
+
+            // Assert
+            result.Should().Be(expected);
+        }
+    }
+}

--- a/FluentTc/ConnectedTc.cs
+++ b/FluentTc/ConnectedTc.cs
@@ -142,7 +142,12 @@ namespace FluentTc
         /// <param name="parameterName">Parameter name to be deleted</param>
         void DeleteBuildConfigurationParameter(Action<IBuildConfigurationHavingBuilder> buildConfigurationOrTemplate, Action<IBuildParameterHavingBuilder> parameterName);
 
-        BuildStatistics GetBuildStatistics(Action<IBuildHavingBuilder> having);
+        /// <summary>
+        /// Retrieves build statistics according to the provided build criteria
+        /// </summary>
+        /// <param name="having">Build criteria</param>
+        /// <returns>List of build statistics</returns>
+        IList<IBuildStatistic> GetBuildStatistics(Action<IBuildHavingBuilder> having);
     }
 
     internal class ConnectedTc : IConnectedTc
@@ -438,9 +443,14 @@ namespace FluentTc
             m_BuildConfigurationRetriever.DeleteBuildConfigurationParameter(buildConfigurationOrTemplate, parameterName);
         }
 
-        public BuildStatistics GetBuildStatistics(Action<IBuildHavingBuilder> having)
+        /// <summary>
+        /// Retrieves build statistics according to the provided build criteria
+        /// </summary>
+        /// <param name="having">Build criteria</param>
+        /// <returns>List of build statistics</returns>
+        public IList<IBuildStatistic> GetBuildStatistics(Action<IBuildHavingBuilder> having)
         {
-            return m_StatisticsRetriever.GetStatistics(having);
+            return m_StatisticsRetriever.GetBuildStatistics(having);
         }
     }
 }

--- a/FluentTc/Domain/BuildStatisticsModel.cs
+++ b/FluentTc/Domain/BuildStatisticsModel.cs
@@ -1,11 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System.Collections.Generic;
 
 namespace FluentTc.Domain
 {
-    public class BuildStatistics
+    public class BuildStatisticsModel
     {
         public string Count { get; set; }
         public List<Property> Property { get; set; }

--- a/FluentTc/Domain/IBuildStatistic.cs
+++ b/FluentTc/Domain/IBuildStatistic.cs
@@ -1,0 +1,30 @@
+﻿namespace FluentTc.Domain
+{
+    public interface IBuildStatistic
+    {
+        string Name { get; }
+        string Value { get; }
+    }
+
+    public class BuildStatistic : IBuildStatistic
+    {
+        private readonly string m_Name;
+        private readonly string m_Value;
+
+        public BuildStatistic(string name, string value)
+        {
+            m_Name = name;
+            m_Value = value;
+        }
+
+        public string Name
+        {
+            get { return m_Name; }
+        }
+
+        public string Value
+        {
+            get { return m_Value; }
+        }
+    }
+}

--- a/FluentTc/Engine/BuildStatisticConverter.cs
+++ b/FluentTc/Engine/BuildStatisticConverter.cs
@@ -1,0 +1,28 @@
+﻿using System.Collections.Generic;
+using FluentTc.Domain;
+using System.Linq;
+
+namespace FluentTc.Engine
+{
+    internal interface IBuildStatisticConverter
+    {
+        IList<IBuildStatistic> Convert(BuildStatisticsModel buildStatisticsModel);
+    }
+
+    internal class BuildStatisticConverter : IBuildStatisticConverter
+    {
+        public IList<IBuildStatistic> Convert(BuildStatisticsModel buildStatisticsModel)
+        {
+            if (string.IsNullOrEmpty(buildStatisticsModel.Count) || int.Parse(buildStatisticsModel.Count) <= 0)
+            {
+                return new List<IBuildStatistic>();
+            }
+            return buildStatisticsModel.Property.Select(CreateBuildStatistic).ToList();
+        }
+
+        private static IBuildStatistic CreateBuildStatistic(Property property)
+        {
+            return new BuildStatistic(property.Name, property.Value);
+        }
+    }
+}

--- a/FluentTc/Engine/BuildStatisticsRetriever.cs
+++ b/FluentTc/Engine/BuildStatisticsRetriever.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using FluentTc.Domain;
 using FluentTc.Locators;
 
@@ -9,25 +7,29 @@ namespace FluentTc.Engine
 {
     internal interface IBuildStatisticsRetriever
     {
-        BuildStatistics GetStatistics(Action<IBuildHavingBuilder> having);
+        IList<IBuildStatistic> GetBuildStatistics(Action<IBuildHavingBuilder> having);
     }
     internal class BuildStatisticsRetriever : IBuildStatisticsRetriever
     {
         private readonly ITeamCityCaller m_Caller;
         private readonly IBuildHavingBuilderFactory m_BuildHavingBuilderFactory;
+        private readonly IBuildStatisticConverter m_BuildStatisticConverter;
 
-        public BuildStatisticsRetriever(ITeamCityCaller caller, IBuildHavingBuilderFactory buildHavingBuilderFactory)
+        public BuildStatisticsRetriever(ITeamCityCaller caller, IBuildHavingBuilderFactory buildHavingBuilderFactory, IBuildStatisticConverter buildStatisticConverter)
         {
             m_Caller = caller;
             m_BuildHavingBuilderFactory = buildHavingBuilderFactory;
+            m_BuildStatisticConverter = buildStatisticConverter;
         }
 
-        public BuildStatistics GetStatistics(Action<IBuildHavingBuilder> having)
+        public IList<IBuildStatistic> GetBuildStatistics(Action<IBuildHavingBuilder> having)
         {
             var buildHavingBuilder = m_BuildHavingBuilderFactory.CreateBuildHavingBuilder();
             having(buildHavingBuilder);
             var locator = buildHavingBuilder.GetLocator();
-            return m_Caller.GetFormat<BuildStatistics>("/app/rest/builds/{0}/statistics", locator);
+            var buildStatisticsModel = m_Caller.GetFormat<BuildStatisticsModel>("/app/rest/builds/{0}/statistics", locator);
+
+            return m_BuildStatisticConverter.Convert(buildStatisticsModel);
         }
     }
 }

--- a/FluentTc/FluentTc.csproj
+++ b/FluentTc/FluentTc.csproj
@@ -92,6 +92,7 @@
     <Compile Include="Domain\File.cs" />
     <Compile Include="Domain\FileWrapper.cs" />
     <Compile Include="Domain\Group.cs" />
+    <Compile Include="Domain\IBuildStatistic.cs" />
     <Compile Include="Domain\Investigation.cs" />
     <Compile Include="Domain\InvestigationWrapper.cs" />
     <Compile Include="Domain\Parameters.cs" />
@@ -105,7 +106,7 @@
     <Compile Include="Domain\RoleWrapper.cs" />
     <Compile Include="Domain\SnapshotDependencies.cs" />
     <Compile Include="Domain\SnapshotDependency.cs" />
-    <Compile Include="Domain\BuildStatistics.cs" />
+    <Compile Include="Domain\BuildStatisticsModel.cs" />
     <Compile Include="Domain\Test.cs" />
     <Compile Include="Domain\TestOccurrence.cs" />
     <Compile Include="Domain\TestOccurrenceWrapper.cs" />
@@ -134,6 +135,7 @@
     <Compile Include="Engine\CountBuilderFactory.cs" />
     <Compile Include="Engine\BuildConfigurationTemplateRetriever.cs" />
     <Compile Include="Engine\IBuildParameterHavingBuilder.cs" />
+    <Compile Include="Engine\BuildStatisticConverter.cs" />
     <Compile Include="Engine\ProjectPropertySetter.cs" />
     <Compile Include="Engine\NewProjectDetailsBuilder.cs" />
     <Compile Include="Engine\ProjectCreator.cs" />

--- a/FluentTc/FluentTc.csproj
+++ b/FluentTc/FluentTc.csproj
@@ -169,7 +169,9 @@
     <Compile Include="Locators\BuildConfigurationHavingBuilderFactory.cs" />
     <Compile Include="Locators\BuildHavingBuilder.cs" />
     <Compile Include="Locators\BuildHavingBuilderFactory.cs" />
+    <Compile Include="Locators\BuildParameterCheckboxTypeBuilder.cs" />
     <Compile Include="Locators\BuildParametersBuilder.cs" />
+    <Compile Include="Locators\BuildParameterTextTypeBuilder.cs" />
     <Compile Include="Locators\BuildParameterValueBuilder.cs" />
     <Compile Include="Locators\BuildProjectHavingBuilder.cs" />
     <Compile Include="Locators\BuildIncludeBuilder.cs" />
@@ -181,6 +183,8 @@
     <Compile Include="Locators\BuildAdditionalIncludeBuilder.cs" />
     <Compile Include="Locators\ChangesHavingBuilder.cs" />
     <Compile Include="Locators\ChangesIncludeBuilder.cs" />
+    <Compile Include="Locators\BuildParameterTypeBuilder.cs" />
+    <Compile Include="Locators\BuildParameterSelectListTypeBuilder.cs" />
     <Compile Include="Locators\LocatorBuilder.cs" />
     <Compile Include="Locators\QueueHavingBuilder.cs" />
     <Compile Include="Locators\AgentHavingBuilder.cs" />

--- a/FluentTc/Locators/BuildParameterCheckboxTypeBuilder.cs
+++ b/FluentTc/Locators/BuildParameterCheckboxTypeBuilder.cs
@@ -1,0 +1,39 @@
+﻿using System.Text;
+
+namespace FluentTc.Locators
+{
+    public interface IBuildParameterCheckboxTypeBuilder
+    {
+        IBuildParameterCheckboxTypeBuilder WithCheckedValue(string checkedValue);
+        IBuildParameterCheckboxTypeBuilder WithUncheckedValue(string uncheckedValue);
+    }
+
+    internal class BuildParameterCheckboxTypeBuilder : IBuildParameterCheckboxTypeBuilder
+    {
+        private string m_checkedValue;
+        private string m_uncheckedValue;
+
+        public IBuildParameterCheckboxTypeBuilder WithCheckedValue(string checkedValue)
+        {
+            m_checkedValue = checkedValue;
+            return this;
+        }
+
+        public IBuildParameterCheckboxTypeBuilder WithUncheckedValue(string uncheckedValue)
+        {
+            m_uncheckedValue = uncheckedValue;
+            return this;
+        }
+
+        public string Build()
+        {
+            var builder = new StringBuilder();
+            builder.Append("checkbox");
+            if (!string.IsNullOrEmpty(m_checkedValue))
+                builder.Append(" checkedValue='").Append(m_checkedValue).Append("'");
+            if (!string.IsNullOrEmpty(m_uncheckedValue))
+                builder.Append(" uncheckedValue='").Append(m_uncheckedValue).Append("'");
+            return builder.ToString();
+        }
+    }
+}

--- a/FluentTc/Locators/BuildParameterSelectListTypeBuilder.cs
+++ b/FluentTc/Locators/BuildParameterSelectListTypeBuilder.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace FluentTc.Locators
+{
+    public interface IBuildParameterSelectListTypeBuilder
+    {
+        IBuildParameterSelectListTypeBuilder Value(string value);
+        IBuildParameterSelectListTypeBuilder LabeledValue(string label, string value);
+        IBuildParameterSelectListTypeBuilder AllowMultiple(bool allowMultiple);
+        IBuildParameterSelectListTypeBuilder WithSeparator(string separator);
+    }
+
+    internal class BuildParameterSelectListTypeBuilder : IBuildParameterSelectListTypeBuilder
+    {
+        private readonly List<Tuple<string, string>> m_values = new List<Tuple<string, string>>();
+
+        private string m_separator = null;
+        private bool m_multiple;
+
+        public IBuildParameterSelectListTypeBuilder Value(string value)
+        {
+            if (!string.IsNullOrEmpty(value))
+                m_values.Add(new Tuple<string, string>(null, value));
+            return this;
+        }
+
+        public IBuildParameterSelectListTypeBuilder LabeledValue(string label, string value)
+        {
+            if (!string.IsNullOrEmpty(value))
+                m_values.Add(new Tuple<string, string>(label, value));
+            return this;
+        }
+
+        public IBuildParameterSelectListTypeBuilder AllowMultiple(bool allowMultiple)
+        {
+            m_multiple = allowMultiple;
+            return this;
+        }
+
+        public IBuildParameterSelectListTypeBuilder WithSeparator(string separator)
+        {
+            if (!string.IsNullOrEmpty(separator))
+                m_separator = separator;
+            return this;
+        }
+
+        public string Build()
+        {
+            var builder = new StringBuilder();
+            if (!m_values.Any())
+                return string.Empty;
+            builder.Append("select");
+            if (m_multiple)
+            {
+                builder.Append(" multiple='true'");
+                if (!string.IsNullOrEmpty(m_separator))
+                    builder.Append(" valueSeparator='").Append(m_separator).Append("'");
+            }
+            for (var i = 0; i < m_values.Count; i++)
+            {
+                if (!string.IsNullOrEmpty(m_values[i].Item1))
+                    builder.Append(" label_").Append(i + 1).Append("='").Append(m_values[i].Item1).Append("'");
+                builder.Append(" data_").Append(i + 1).Append("='").Append(m_values[i].Item2).Append("'");
+            }
+            return builder.ToString();
+        }
+    }
+}

--- a/FluentTc/Locators/BuildParameterTextTypeBuilder.cs
+++ b/FluentTc/Locators/BuildParameterTextTypeBuilder.cs
@@ -1,0 +1,60 @@
+﻿using System.Text;
+
+namespace FluentTc.Locators
+{
+    public interface IBuildParameterTextTypeBuilder
+    {
+        IBuildParameterTextTypeBuilder AsAny();
+        IBuildParameterTextTypeBuilder AsNotEmpty();
+        IBuildParameterTextTypeBuilder AsRegex(string regexp, string validationMessage);
+    }
+
+    internal class BuildParameterTextTypeBuilder : IBuildParameterTextTypeBuilder
+    {
+        private const string AnyValidation = "any";
+        private const string RegexValidation = "regex";
+        private const string NotEmptyValidation = "not_empty";
+
+        private const string DefaultValidation = AnyValidation;
+
+        private string m_mode = DefaultValidation;
+        private string m_regexp;
+        private string m_message;
+
+        public IBuildParameterTextTypeBuilder AsAny()
+        {
+            m_mode = AnyValidation;
+            m_regexp = null;
+            m_message = null;
+            return this;
+        }
+
+        public IBuildParameterTextTypeBuilder AsNotEmpty()
+        {
+            m_mode = NotEmptyValidation;
+            m_regexp = null;
+            m_message = null;
+            return this;
+        }
+
+        public IBuildParameterTextTypeBuilder AsRegex(string regexp, string validationMessage)
+        {
+            m_mode = RegexValidation;
+            m_regexp = regexp;
+            m_message = validationMessage;
+            return this;
+        }
+
+        public string Build()
+        {
+            var builder = new StringBuilder();
+            builder.Append("text");
+            builder.Append(" validationMode='").Append(m_mode).Append("'");
+            if (!string.IsNullOrEmpty(m_regexp))
+                builder.Append(" regexp='").Append(m_regexp).Append("'");
+            if (!string.IsNullOrEmpty(m_message))
+                builder.Append(" validationMessage='").Append(m_message).Append("'");
+            return builder.ToString();
+        }
+    }
+}

--- a/FluentTc/Locators/BuildParameterTypeBuilder.cs
+++ b/FluentTc/Locators/BuildParameterTypeBuilder.cs
@@ -1,0 +1,114 @@
+﻿using System;
+using System.Text;
+
+namespace FluentTc.Locators
+{
+    public interface IBuildParameterTypeBuilder
+    {
+        IBuildParameterTypeBuilder WithDisplayNormal();
+        IBuildParameterTypeBuilder WithDisplayHidden();
+        IBuildParameterTypeBuilder WithDisplayPrompt();
+        IBuildParameterTypeBuilder WithDescription(string description);
+        IBuildParameterTypeBuilder WithLabel(string label);
+        IBuildParameterTypeBuilder AsSelectList(Action<IBuildParameterSelectListTypeBuilder> selectListBuilder);
+        IBuildParameterTypeBuilder AsCheckbox(Action<IBuildParameterCheckboxTypeBuilder> checkboxBuilder);
+        IBuildParameterTypeBuilder AsPassword();
+        IBuildParameterTypeBuilder AsText(Action<IBuildParameterTextTypeBuilder> textBuilder);
+    }
+
+    internal class BuildParameterTypeBuilder : IBuildParameterTypeBuilder
+    {
+        private const string DisplayNormal = "normal";
+        private const string DisplayHidden = "hidden";
+        private const string DisplayPrompt = "prompt";
+
+        private const string DefaultDisplay = DisplayNormal;
+
+        private string m_display = DefaultDisplay;
+        private string m_description;
+        private string m_label;
+        private string m_special;
+
+        public IBuildParameterTypeBuilder WithDisplayNormal()
+        {
+            m_display = DisplayNormal;
+            return this;
+        }
+
+        public IBuildParameterTypeBuilder WithDisplayHidden()
+        {
+            m_display = DisplayHidden;
+            return this;
+        }
+
+        public IBuildParameterTypeBuilder WithDisplayPrompt()
+        {
+            m_display = DisplayPrompt;
+            return this;
+        }
+
+        public IBuildParameterTypeBuilder WithDescription(string description)
+        {
+            if (!string.IsNullOrEmpty(description))
+                m_description = description;
+            return this;
+        }
+
+        public IBuildParameterTypeBuilder WithLabel(string label)
+        {
+            if (!string.IsNullOrEmpty(label))
+                m_label = label;
+            return this;
+        }
+
+        public IBuildParameterTypeBuilder AsSelectList(Action<IBuildParameterSelectListTypeBuilder> selectListBuilder)
+        {
+            var builder = new BuildParameterSelectListTypeBuilder();
+            selectListBuilder(builder);
+            var special = builder.Build();
+            if (!string.IsNullOrEmpty(special))
+                m_special = special;
+            return this;
+        }
+
+        public IBuildParameterTypeBuilder AsCheckbox(Action<IBuildParameterCheckboxTypeBuilder> checkboxBuilder)
+        {
+            var builder = new BuildParameterCheckboxTypeBuilder();
+            checkboxBuilder(builder);
+            var special = builder.Build();
+            if (!string.IsNullOrEmpty(special))
+                m_special = special;
+            return this;
+        }
+
+        public IBuildParameterTypeBuilder AsText(Action<IBuildParameterTextTypeBuilder> textBuilder)
+        {
+            var builder = new BuildParameterTextTypeBuilder();
+            textBuilder(builder);
+            var special = builder.Build();
+            if (!string.IsNullOrEmpty(special))
+                m_special = special;
+            return this;
+        }
+
+        public IBuildParameterTypeBuilder AsPassword()
+        {
+            m_special = "password";
+            return this;
+        }
+
+        public string Build()
+        {
+            var builder = new StringBuilder();
+            if (string.IsNullOrEmpty(m_special))
+                return string.Empty;
+            builder.Append(m_special);
+            if (!string.IsNullOrEmpty(m_label))
+                builder.Append(" label='").Append(m_label).Append("'");
+            if (!string.IsNullOrEmpty(m_description))
+                builder.Append(" description='").Append(m_description).Append("'");
+            builder.Append(" display='").Append(m_display).Append("'");
+            return builder.ToString();
+        }
+    }
+}

--- a/FluentTc/Locators/BuildParameterValueBuilder.cs
+++ b/FluentTc/Locators/BuildParameterValueBuilder.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using FluentTc.Domain;
 
 namespace FluentTc.Locators
@@ -6,7 +7,7 @@ namespace FluentTc.Locators
     public interface IBuildParameterValueBuilder
     {
         IBuildParameterValueBuilder Parameter(string name, string value);
-        IBuildParameterValueBuilder Parameter(string name, string value, string rawValue);
+        IBuildParameterValueBuilder Parameter(string name, string value, Action<IBuildParameterTypeBuilder> type);
     }
 
     public class BuildParameterValueBuilder : IBuildParameterValueBuilder
@@ -19,8 +20,13 @@ namespace FluentTc.Locators
             return this;
         }
 
-        public IBuildParameterValueBuilder Parameter(string name, string value, string rawValue)
+        public IBuildParameterValueBuilder Parameter(string name, string value, Action<IBuildParameterTypeBuilder> typeBuilder)
         {
+            var builder = new BuildParameterTypeBuilder();
+            typeBuilder(builder);
+            var rawValue = builder.Build();
+            if (string.IsNullOrEmpty(rawValue))
+                return Parameter(name, value);
             m_Properties.Add(new Property { Name = name, Value = value, Type = new PropertyType { RawValue = rawValue } });
             return this;
         }


### PR DESCRIPTION
### Issue details

SetBuildConfigurationParameters was improved by @sokolovsv90 and it supports now builder for parameter type

### Relates to issue
None

### Checklist
- [x] All unit tests passed on build server
- [ ] Acceptance test(s) covers new/modified functionality 
- [x] Code coverage is at least the same or higher
- [ ] Breaking change in public API

# Example of using new/modified functionality

```C#
[Test]
public void Test_To_Reproduce_The_Issue()
{
            connectedTc.SetBuildConfigurationParameters(_ => _.Name("FluentTc"), 
                p => p.Parameter("name", "newVal", t => t.AsSelectList(s => s.Value("lol"))));
}
```