### PR TITLE
Build Properties

### DIFF
--- a/FluentTc.Tests/Domain/BuildTests.cs
+++ b/FluentTc.Tests/Domain/BuildTests.cs
@@ -16,7 +16,8 @@ namespace FluentTc.Tests.Domain
             // Arrange
             var build = new Build(1, "2", BuildStatus.Success, new DateTime(), new DateTime(), new DateTime(), null,
                 null,
-                new List<Change>(), "");
+                new List<Change>(), "",
+                null);
 
             // Act
             build.SetBuildConfiguration(new BuildConfiguration {Id = "ConfigId"});

--- a/FluentTc.Tests/Engine/BuildModelToBuildConverterTests.cs
+++ b/FluentTc.Tests/Engine/BuildModelToBuildConverterTests.cs
@@ -93,5 +93,28 @@ namespace FluentTc.Tests.Engine
             builds.Single().Status.HasValue.Should().BeFalse();
             builds.Single().BuildConfiguration.Id.Should().Be("bt2");
         }
+
+        [Test]
+        public void ConvertToBuilds_BuildProperties()
+        {
+            var buildModelToBuildConverter = new BuildModelToBuildConverter();
+            var buildWrapper = new BuildWrapper
+            {
+                Build = new List<BuildModel> {new BuildModel
+                {
+                    Status = "SUCCESS",
+                    Properties = new Properties
+                    {
+                        Property = new List<Property> { new Property { Name = "Property1", Value = "Value1"} }
+                    }
+                }},
+                Count = "1"
+            };
+            var builds = buildModelToBuildConverter.ConvertToBuilds(buildWrapper);
+
+            // Assert
+            builds.Single().Properties.Property.Single().Name.Should().Be("Property1");
+            builds.Single().Properties.Property.Single().Value.Should().Be("Value1");
+        }
     }
 }

--- a/FluentTc/Domain/Build.cs
+++ b/FluentTc/Domain/Build.cs
@@ -16,6 +16,7 @@ namespace FluentTc.Domain
         Agent Agent { get; }
         List<Change> Changes { get; }
         string WebUrl { get; }
+        Properties Properties { get; }
         void SetChanges(List<Change> changes);
         void SetBuildConfiguration(BuildConfiguration buildConfiguration);
     }
@@ -32,9 +33,11 @@ namespace FluentTc.Domain
         private readonly DateTime m_StartDate;
         private readonly BuildStatus? m_Status;
         private readonly string m_WebUrl;
+        private readonly Properties m_Properties;
 
         public Build(long id, string number, BuildStatus? status, DateTime startDate, DateTime finishDate,
-            DateTime queuedDate, BuildConfiguration buildConfiguration, Agent agent, List<Change> changes, string webUrl)
+            DateTime queuedDate, BuildConfiguration buildConfiguration, Agent agent, List<Change> changes, string webUrl,
+            Properties properties)
         {
             m_Id = id;
             m_Number = number;
@@ -46,6 +49,7 @@ namespace FluentTc.Domain
             m_Agent = agent;
             m_Changes = changes;
             m_WebUrl = webUrl;
+            m_Properties = properties;
         }
 
         public long Id
@@ -96,6 +100,11 @@ namespace FluentTc.Domain
         public string WebUrl
         {
             get { return m_WebUrl; }
+        }
+
+        public Properties Properties
+        {
+            get { return m_Properties; }
         }
 
         public void SetChanges(List<Change> changes)

--- a/FluentTc/Domain/BuildModel.cs
+++ b/FluentTc/Domain/BuildModel.cs
@@ -21,5 +21,6 @@ namespace FluentTc.Domain
         public ChangesList LastChanges { get; set; }
         public ChangesWrapper Changes { get; set; }
         public List<Change> BuildChanges { get; set; }
+        public Properties Properties { get; set; }
     }
 }

--- a/FluentTc/Engine/BuildModelToBuildConverter.cs
+++ b/FluentTc/Engine/BuildModelToBuildConverter.cs
@@ -32,7 +32,7 @@ namespace FluentTc.Engine
             return new Build(buildModel.Id, buildModel.Number,
                 ConvertBuildStatus(buildModel),
                 buildModel.StartDate, buildModel.FinishDate, buildModel.QueuedDate, buildConfiguration,
-                buildModel.Agent, changes, buildModel.WebUrl);
+                buildModel.Agent, changes, buildModel.WebUrl, buildModel.Properties);
         }
 
         private static BuildStatus? ConvertBuildStatus(BuildModel buildModel)


### PR DESCRIPTION
TeamCity api provides Properties for build(/app/rest/builds/id:{id}).
Need to add Properties to Build class.

Issue #69 

### Checklist
- [x] All unit tests passed on build server
- [x] Acceptance test(s) covers new/modified functionality 
- [ ] Code coverage is at least the same or higher
- [x] Breaking change in public API

var myProperty = new RemoteTc().Connect(_ => _.ToHost("tc"))
                .GetBuild(123456).Properties.Property.Where(p => p.Name == "MyProperty");