### PR TITLE
Build result from runner

### DIFF
--- a/FluentTc.Samples/Program.cs
+++ b/FluentTc.Samples/Program.cs
@@ -210,17 +210,17 @@ namespace FluentTc.Samples
                 .SetBuildConfigurationParameters(_ => _.Id("bt2"),
                     _ => _.Parameter("name", "value").Parameter("name2", "value"));
 
-            new RemoteTc().Connect(_ => _.ToHost("tc"))
+            build = new RemoteTc().Connect(_ => _.ToHost("tc"))
                 .RunBuildConfiguration(_ => _.Id("bt2"));
 
-            new RemoteTc().Connect(_ => _.ToHost("tc"))
+            build = new RemoteTc().Connect(_ => _.ToHost("tc"))
                 .RunBuildConfiguration(_ => _.Id("bt2"),
                     _ => _.Parameter("name", "value").Parameter("name2", "value"));
 
-            new RemoteTc().Connect(_ => _.ToHost("tc"))
+            build = new RemoteTc().Connect(_ => _.ToHost("tc"))
                 .RunBuildConfiguration(having => having.Id("bt2"), onAgent => onAgent.Name("agent1"));
 
-            new RemoteTc().Connect(_ => _.ToHost("tc"))
+            build = new RemoteTc().Connect(_ => _.ToHost("tc"))
                 .RunBuildConfiguration(_ => _.Id("bt2"), _ => _.Name("agent1"),
                     _ => _.Parameter("name", "value").Parameter("name2", "value"));
 

--- a/FluentTc.Tests/AcceptanceTests.cs
+++ b/FluentTc.Tests/AcceptanceTests.cs
@@ -453,6 +453,31 @@ namespace FluentTc.Tests
         }
 
         [Test]
+        public void RunBuildConfiguration_BuildResponse()
+        {
+            // Arrange
+            Action<IBuildConfigurationHavingBuilder> having = _ => _.Name("FluentTc");
+            var teamCityCaller = CreateTeamCityCaller();
+            var buildConfigurationRetriever = A.Fake<IBuildConfigurationRetriever>();
+
+            A.CallTo(() => buildConfigurationRetriever.GetSingleBuildConfiguration(having))
+                .Returns(new BuildConfiguration { Id = "bt2" });
+            A.CallTo(
+                () =>
+                    teamCityCaller.PostFormat<BuildModel>(A<string>.Ignored,
+                    HttpContentTypes.ApplicationXml, HttpContentTypes.ApplicationJson, A<string>.Ignored, A<object[]>.Ignored))
+                        .Returns(new BuildModel { Id = 123 });
+
+            var connectedTc = new RemoteTc().Connect(_ => _.AsGuest(), teamCityCaller, buildConfigurationRetriever);
+
+            // Act
+            var build = connectedTc.RunBuildConfiguration(having);
+
+            // Assert
+            build.Id.Should().Be(123);
+        }
+
+        [Test]
         public void GetBuildConfigurations_ByName()
         {
             // Arrange

--- a/FluentTc.Tests/AcceptanceTests.cs
+++ b/FluentTc.Tests/AcceptanceTests.cs
@@ -217,6 +217,11 @@ namespace FluentTc.Tests
 
             A.CallTo(() => buildConfigurationRetriever.GetSingleBuildConfiguration(having))
                 .Returns(new BuildConfiguration { Id = "bt2" });
+            A.CallTo(() =>
+                teamCityCaller.PostFormat<BuildModel>(
+                    "<build>\r\n<buildType id=\"bt2\"/>\r\n<comment><text>comment!</text></comment>\r\n</build>\r\n",
+                    HttpContentTypes.ApplicationXml, HttpContentTypes.ApplicationJson, "/app/rest/buildQueue"))
+                .Returns(new BuildModel {Id = 123, Status = "SUCCESS"});
 
             var connectedTc = new RemoteTc().Connect(_ => _.AsGuest(), teamCityCaller, buildConfigurationRetriever);
 
@@ -224,11 +229,13 @@ namespace FluentTc.Tests
             var build = connectedTc.RunBuildConfiguration(having, options => options.WithComment("comment!"));
 
             // Assert
-            A.CallTo(
-                () =>
-                    teamCityCaller.PostFormat<BuildModel>("<build>\r\n<buildType id=\"bt2\"/>\r\n<comment><text>comment!</text></comment>\r\n</build>\r\n",
+            A.CallTo(() =>
+                teamCityCaller.PostFormat<BuildModel>(
+                    "<build>\r\n<buildType id=\"bt2\"/>\r\n<comment><text>comment!</text></comment>\r\n</build>\r\n",
                     HttpContentTypes.ApplicationXml, HttpContentTypes.ApplicationJson, "/app/rest/buildQueue"))
-                        .MustHaveHappened(Repeated.Exactly.Once);
+                .MustHaveHappened(Repeated.Exactly.Once);
+            build.Id.ShouldBeEquivalentTo(123);
+            build.Status.ShouldBeEquivalentTo(BuildStatus.Success);
         }
         
         [Test]
@@ -241,6 +248,11 @@ namespace FluentTc.Tests
 
             A.CallTo(() => buildConfigurationRetriever.GetSingleBuildConfiguration(having))
                 .Returns(new BuildConfiguration { Id = "bt2" });
+            A.CallTo(() =>
+                teamCityCaller.PostFormat<BuildModel>(
+                    "<build>\r\n<buildType id=\"bt2\"/>\r\n<comment><text>comment&lt;HAHA&gt;</text></comment>\r\n</build>\r\n",
+                    HttpContentTypes.ApplicationXml, HttpContentTypes.ApplicationJson, "/app/rest/buildQueue"))
+                .Returns(new BuildModel {Id = 123, Status = "SUCCESS"});
 
             var connectedTc = new RemoteTc().Connect(_ => _.AsGuest(), teamCityCaller, buildConfigurationRetriever);
 
@@ -248,11 +260,13 @@ namespace FluentTc.Tests
             var build = connectedTc.RunBuildConfiguration(having, options => options.WithComment("comment<HAHA>"));
 
             // Assert
-            A.CallTo(
-                () =>
-                    teamCityCaller.PostFormat<BuildModel>("<build>\r\n<buildType id=\"bt2\"/>\r\n<comment><text>comment&lt;HAHA&gt;</text></comment>\r\n</build>\r\n",
+            A.CallTo(() =>
+                teamCityCaller.PostFormat<BuildModel>(
+                    "<build>\r\n<buildType id=\"bt2\"/>\r\n<comment><text>comment&lt;HAHA&gt;</text></comment>\r\n</build>\r\n",
                     HttpContentTypes.ApplicationXml, HttpContentTypes.ApplicationJson, "/app/rest/buildQueue"))
-                        .MustHaveHappened(Repeated.Exactly.Once);
+                .MustHaveHappened(Repeated.Exactly.Once);
+            build.Id.ShouldBeEquivalentTo(123);
+            build.Status.ShouldBeEquivalentTo(BuildStatus.Success);
         }
 
         [Test]
@@ -265,6 +279,11 @@ namespace FluentTc.Tests
 
             A.CallTo(() => buildConfigurationRetriever.GetSingleBuildConfiguration(having))
                 .Returns(new BuildConfiguration { Id = "bt2" });
+            A.CallTo(() =>
+                teamCityCaller.PostFormat<BuildModel>(
+                    "<build personal=\"true\">\r\n<buildType id=\"bt2\"/>\r\n<comment><text>comment!</text></comment>\r\n</build>\r\n",
+                    HttpContentTypes.ApplicationXml, HttpContentTypes.ApplicationJson, "/app/rest/buildQueue"))
+                .Returns(new BuildModel {Id = 123, Status = "SUCCESS"});
 
             var connectedTc = new RemoteTc().Connect(_ => _.AsGuest(), teamCityCaller, buildConfigurationRetriever);
 
@@ -272,11 +291,13 @@ namespace FluentTc.Tests
             var build = connectedTc.RunBuildConfiguration(having, options => options.WithComment("comment!").AsPersonal());
 
             // Assert
-            A.CallTo(
-                () =>
-                    teamCityCaller.PostFormat<BuildModel>("<build personal=\"true\">\r\n<buildType id=\"bt2\"/>\r\n<comment><text>comment!</text></comment>\r\n</build>\r\n",
+            A.CallTo(() =>
+                teamCityCaller.PostFormat<BuildModel>(
+                    "<build personal=\"true\">\r\n<buildType id=\"bt2\"/>\r\n<comment><text>comment!</text></comment>\r\n</build>\r\n",
                     HttpContentTypes.ApplicationXml, HttpContentTypes.ApplicationJson, "/app/rest/buildQueue"))
-                        .MustHaveHappened(Repeated.Exactly.Once);
+                .MustHaveHappened(Repeated.Exactly.Once);
+            build.Id.ShouldBeEquivalentTo(123);
+            build.Status.ShouldBeEquivalentTo(BuildStatus.Success);
         }
 
         [Test]
@@ -289,6 +310,11 @@ namespace FluentTc.Tests
 
             A.CallTo(() => buildConfigurationRetriever.GetSingleBuildConfiguration(having))
                 .Returns(new BuildConfiguration { Id = "bt2" });
+            A.CallTo(() =>
+                teamCityCaller.PostFormat<BuildModel>(
+                    "<build personal=\"true\">\r\n<buildType id=\"bt2\"/>\r\n<comment><text>comment!</text></comment>\r\n<triggeringOptions cleanSources=\"true\" />\r\n</build>\r\n",
+                    HttpContentTypes.ApplicationXml, HttpContentTypes.ApplicationJson, "/app/rest/buildQueue"))
+                .Returns(new BuildModel {Id = 123, Status = "SUCCESS"});
 
             var connectedTc = new RemoteTc().Connect(_ => _.AsGuest(), teamCityCaller, buildConfigurationRetriever);
 
@@ -296,11 +322,13 @@ namespace FluentTc.Tests
             var build = connectedTc.RunBuildConfiguration(having, options => options.WithComment("comment!").AsPersonal().WithCleanSources());
 
             // Assert
-            A.CallTo(
-                () =>
-                    teamCityCaller.PostFormat<BuildModel>("<build personal=\"true\">\r\n<buildType id=\"bt2\"/>\r\n<comment><text>comment!</text></comment>\r\n<triggeringOptions cleanSources=\"true\" />\r\n</build>\r\n",
+            A.CallTo(() =>
+                teamCityCaller.PostFormat<BuildModel>(
+                    "<build personal=\"true\">\r\n<buildType id=\"bt2\"/>\r\n<comment><text>comment!</text></comment>\r\n<triggeringOptions cleanSources=\"true\" />\r\n</build>\r\n",
                     HttpContentTypes.ApplicationXml, HttpContentTypes.ApplicationJson, "/app/rest/buildQueue"))
-                        .MustHaveHappened(Repeated.Exactly.Once);
+                .MustHaveHappened(Repeated.Exactly.Once);
+            build.Id.ShouldBeEquivalentTo(123);
+            build.Status.ShouldBeEquivalentTo(BuildStatus.Success);
         }
 
         [Test]
@@ -313,6 +341,11 @@ namespace FluentTc.Tests
 
             A.CallTo(() => buildConfigurationRetriever.GetSingleBuildConfiguration(having))
                 .Returns(new BuildConfiguration { Id = "bt2" });
+            A.CallTo(() =>
+                teamCityCaller.PostFormat<BuildModel>(
+                    "<build>\r\n<buildType id=\"bt2\"/>\r\n<triggeringOptions cleanSources=\"true\" queueAtTop=\"true\" />\r\n</build>\r\n",
+                    HttpContentTypes.ApplicationXml, HttpContentTypes.ApplicationJson, "/app/rest/buildQueue"))
+                .Returns(new BuildModel {Id = 123, Status = "SUCCESS"});
 
             var connectedTc = new RemoteTc().Connect(_ => _.AsGuest(), teamCityCaller, buildConfigurationRetriever);
 
@@ -320,11 +353,13 @@ namespace FluentTc.Tests
             var build = connectedTc.RunBuildConfiguration(having, options => options.WithCleanSources().QueueAtTop());
 
             // Assert
-            A.CallTo(
-                () =>
-                    teamCityCaller.PostFormat<BuildModel>("<build>\r\n<buildType id=\"bt2\"/>\r\n<triggeringOptions cleanSources=\"true\" queueAtTop=\"true\" />\r\n</build>\r\n",
+            A.CallTo(() =>
+                teamCityCaller.PostFormat<BuildModel>(
+                    "<build>\r\n<buildType id=\"bt2\"/>\r\n<triggeringOptions cleanSources=\"true\" queueAtTop=\"true\" />\r\n</build>\r\n",
                     HttpContentTypes.ApplicationXml, HttpContentTypes.ApplicationJson, "/app/rest/buildQueue"))
-                        .MustHaveHappened(Repeated.Exactly.Once);
+                .MustHaveHappened(Repeated.Exactly.Once);
+            build.Id.ShouldBeEquivalentTo(123);
+            build.Status.ShouldBeEquivalentTo(BuildStatus.Success);
         }
 
         [Test]
@@ -337,6 +372,11 @@ namespace FluentTc.Tests
 
             A.CallTo(() => buildConfigurationRetriever.GetSingleBuildConfiguration(having))
                 .Returns(new BuildConfiguration { Id = "bt2" });
+            A.CallTo(() =>
+                teamCityCaller.PostFormat<BuildModel>(
+                    "<build>\r\n<buildType id=\"bt2\"/>\r\n</build>\r\n",
+                    HttpContentTypes.ApplicationXml, HttpContentTypes.ApplicationJson, "/app/rest/buildQueue"))
+                .Returns(new BuildModel {Id = 123, Status = "SUCCESS"});
 
             var connectedTc = new RemoteTc().Connect(_ => _.AsGuest(), teamCityCaller, buildConfigurationRetriever);
 
@@ -344,11 +384,13 @@ namespace FluentTc.Tests
             var build = connectedTc.RunBuildConfiguration(having);
 
             // Assert
-            A.CallTo(
-                () =>
-                    teamCityCaller.PostFormat<BuildModel>("<build>\r\n<buildType id=\"bt2\"/>\r\n</build>\r\n",
+            A.CallTo(() =>
+                teamCityCaller.PostFormat<BuildModel>(
+                    "<build>\r\n<buildType id=\"bt2\"/>\r\n</build>\r\n",
                     HttpContentTypes.ApplicationXml, HttpContentTypes.ApplicationJson, A<string>.Ignored, A<object[]>.Ignored))
-                        .MustHaveHappened(Repeated.Exactly.Once);
+                .MustHaveHappened(Repeated.Exactly.Once);
+            build.Id.ShouldBeEquivalentTo(123);
+            build.Status.ShouldBeEquivalentTo(BuildStatus.Success);
         }
 
         [Test]
@@ -360,6 +402,11 @@ namespace FluentTc.Tests
             var buildConfigurationRetriever = A.Fake<IBuildConfigurationRetriever>();
             A.CallTo(() => buildConfigurationRetriever.GetSingleBuildConfiguration(having))
                 .Returns(new BuildConfiguration {Id = "bt2"});
+            A.CallTo(() =>
+                teamCityCaller.PostFormat<BuildModel>(
+                    "<build>\r\n<buildType id=\"bt2\"/>\r\n</build>\r\n",
+                    HttpContentTypes.ApplicationXml, HttpContentTypes.ApplicationJson, "/app/rest/buildQueue"))
+                .Returns(new BuildModel {Id = 123, Status = "SUCCESS"});
 
             var connectedTc = new RemoteTc().Connect(_ => _.AsGuest(), teamCityCaller, buildConfigurationRetriever);
 
@@ -367,11 +414,13 @@ namespace FluentTc.Tests
             var build = connectedTc.RunBuildConfiguration(having);
 
             // Assert
-            A.CallTo(
-                () =>
-                    teamCityCaller.PostFormat<BuildModel>("<build>\r\n<buildType id=\"bt2\"/>\r\n</build>\r\n",
+            A.CallTo(() =>
+                teamCityCaller.PostFormat<BuildModel>(
+                    "<build>\r\n<buildType id=\"bt2\"/>\r\n</build>\r\n",
                     HttpContentTypes.ApplicationXml, HttpContentTypes.ApplicationJson, "/app/rest/buildQueue", A<object[]>.Ignored))
-                        .MustHaveHappened(Repeated.Exactly.Once);
+                .MustHaveHappened(Repeated.Exactly.Once);
+            build.Id.ShouldBeEquivalentTo(123);
+            build.Status.ShouldBeEquivalentTo(BuildStatus.Success);
         }
 
         [Test]
@@ -383,6 +432,11 @@ namespace FluentTc.Tests
             var buildConfigurationRetriever = A.Fake<IBuildConfigurationRetriever>();
             A.CallTo(() => buildConfigurationRetriever.GetSingleBuildConfiguration(having))
                 .Returns(new BuildConfiguration {Id = "bt2"});
+            A.CallTo(() =>
+                teamCityCaller.PostFormat<BuildModel>(
+                    "<build>\r\n<buildType id=\"bt2\"/>\r\n<properties>\r\n<property name=\"param1\" value=\"value1\"/>\r\n</properties>\r\n</build>\r\n",
+                    HttpContentTypes.ApplicationXml, HttpContentTypes.ApplicationJson, "/app/rest/buildQueue"))
+                .Returns(new BuildModel {Id = 123, Status = "SUCCESS"});
 
             var connectedTc = new RemoteTc().Connect(_ => _.AsGuest(), teamCityCaller, buildConfigurationRetriever);
 
@@ -390,11 +444,13 @@ namespace FluentTc.Tests
             var build = connectedTc.RunBuildConfiguration(having, p => p.Parameter("param1","value1"));
 
             // Assert
-            A.CallTo(
-                () =>
-                    teamCityCaller.PostFormat<BuildModel>("<build>\r\n<buildType id=\"bt2\"/>\r\n<properties>\r\n<property name=\"param1\" value=\"value1\"/>\r\n</properties>\r\n</build>\r\n",
+            A.CallTo(() =>
+                teamCityCaller.PostFormat<BuildModel>(
+                    "<build>\r\n<buildType id=\"bt2\"/>\r\n<properties>\r\n<property name=\"param1\" value=\"value1\"/>\r\n</properties>\r\n</build>\r\n",
                     HttpContentTypes.ApplicationXml, HttpContentTypes.ApplicationJson, "/app/rest/buildQueue", A<object[]>.Ignored))
-                        .MustHaveHappened(Repeated.Exactly.Once);
+                .MustHaveHappened(Repeated.Exactly.Once);
+            build.Id.ShouldBeEquivalentTo(123);
+            build.Status.ShouldBeEquivalentTo(BuildStatus.Success);
         }
 
         [Test]
@@ -407,6 +463,11 @@ namespace FluentTc.Tests
             var buildConfigurationRetriever = A.Fake<IBuildConfigurationRetriever>();
             A.CallTo(() => buildConfigurationRetriever.GetSingleBuildConfiguration(having))
                 .Returns(new BuildConfiguration {Id = "bt2"});
+            A.CallTo(() =>
+                teamCityCaller.PostFormat<BuildModel>(
+                    "<build>\r\n<buildType id=\"bt2\"/>\r\n<agent id=\"9\"/>\r\n</build>\r\n",
+                    HttpContentTypes.ApplicationXml, HttpContentTypes.ApplicationJson, "/app/rest/buildQueue"))
+                .Returns(new BuildModel {Id = 123, Status = "SUCCESS"});
 
             Action<IAgentHavingBuilder> onAgent = p => p.Name("agent1");
             var agentsRetriever = A.Fake<IAgentsRetriever>();
@@ -418,11 +479,13 @@ namespace FluentTc.Tests
             var build = connectedTc.RunBuildConfiguration(having, onAgent);
 
             // Assert
-            A.CallTo(
-                () =>
-                    teamCityCaller.PostFormat<BuildModel>("<build>\r\n<buildType id=\"bt2\"/>\r\n<agent id=\"9\"/>\r\n</build>\r\n",
+            A.CallTo(() =>
+                teamCityCaller.PostFormat<BuildModel>(
+                    "<build>\r\n<buildType id=\"bt2\"/>\r\n<agent id=\"9\"/>\r\n</build>\r\n",
                     HttpContentTypes.ApplicationXml, HttpContentTypes.ApplicationJson, "/app/rest/buildQueue", A<object[]>.Ignored))
-                        .MustHaveHappened(Repeated.Exactly.Once);
+                .MustHaveHappened(Repeated.Exactly.Once);
+            build.Id.ShouldBeEquivalentTo(123);
+            build.Status.ShouldBeEquivalentTo(BuildStatus.Success);
         }
 
         [Test]
@@ -434,6 +497,11 @@ namespace FluentTc.Tests
             var buildConfigurationRetriever = A.Fake<IBuildConfigurationRetriever>();
             A.CallTo(() => buildConfigurationRetriever.GetSingleBuildConfiguration(having))
                 .Returns(new BuildConfiguration {Id = "bt2"});
+            A.CallTo(() =>
+                teamCityCaller.PostFormat<BuildModel>(
+                    "<build>\r\n<buildType id=\"bt2\"/>\r\n<agent id=\"9\"/>\r\n<properties>\r\n<property name=\"param1\" value=\"value1\"/>\r\n</properties>\r\n</build>\r\n",
+                    HttpContentTypes.ApplicationXml, HttpContentTypes.ApplicationJson, "/app/rest/buildQueue"))
+                .Returns(new BuildModel {Id = 123, Status = "SUCCESS"});
 
             Action<IAgentHavingBuilder> onAgent = p => p.Name("agent1");
             var agentsRetriever = A.Fake<IAgentsRetriever>();
@@ -445,11 +513,13 @@ namespace FluentTc.Tests
             var build = connectedTc.RunBuildConfiguration(having, onAgent, p => p.Parameter("param1", "value1"));
 
             // Assert
-            A.CallTo(
-                () =>
-                    teamCityCaller.PostFormat<BuildModel>("<build>\r\n<buildType id=\"bt2\"/>\r\n<agent id=\"9\"/>\r\n<properties>\r\n<property name=\"param1\" value=\"value1\"/>\r\n</properties>\r\n</build>\r\n",
+            A.CallTo(() =>
+                teamCityCaller.PostFormat<BuildModel>(
+                    "<build>\r\n<buildType id=\"bt2\"/>\r\n<agent id=\"9\"/>\r\n<properties>\r\n<property name=\"param1\" value=\"value1\"/>\r\n</properties>\r\n</build>\r\n",
                     HttpContentTypes.ApplicationXml, HttpContentTypes.ApplicationJson, "/app/rest/buildQueue", A<object[]>.Ignored))
-                        .MustHaveHappened(Repeated.Exactly.Once);
+                .MustHaveHappened(Repeated.Exactly.Once);
+            build.Id.ShouldBeEquivalentTo(123);
+            build.Status.ShouldBeEquivalentTo(BuildStatus.Success);
         }
 
         [Test]
@@ -462,11 +532,10 @@ namespace FluentTc.Tests
 
             A.CallTo(() => buildConfigurationRetriever.GetSingleBuildConfiguration(having))
                 .Returns(new BuildConfiguration { Id = "bt2" });
-            A.CallTo(
-                () =>
-                    teamCityCaller.PostFormat<BuildModel>(A<string>.Ignored,
-                    HttpContentTypes.ApplicationXml, HttpContentTypes.ApplicationJson, A<string>.Ignored, A<object[]>.Ignored))
-                        .Returns(new BuildModel { Id = 123 });
+            A.CallTo(() =>
+                teamCityCaller.PostFormat<BuildModel>("<build>\r\n<buildType id=\"bt2\"/>\r\n</build>\r\n",
+                    HttpContentTypes.ApplicationXml, HttpContentTypes.ApplicationJson, "/app/rest/buildQueue", A<object[]>.Ignored))
+                .Returns(new BuildModel {Id = 123, Status = "SUCCESS"});
 
             var connectedTc = new RemoteTc().Connect(_ => _.AsGuest(), teamCityCaller, buildConfigurationRetriever);
 
@@ -475,6 +544,8 @@ namespace FluentTc.Tests
 
             // Assert
             build.Id.Should().Be(123);
+            build.Id.ShouldBeEquivalentTo(123);
+            build.Status.ShouldBeEquivalentTo(BuildStatus.Success);
         }
 
         [Test]
@@ -483,8 +554,7 @@ namespace FluentTc.Tests
             // Arrange
             Action<IBuildConfigurationHavingBuilder> having = _ => _.Name("FluentTc");
             var teamCityCaller = CreateTeamCityCaller();
-            A.CallTo(
-                () =>
+            A.CallTo(() =>
                     teamCityCaller.Get<BuildTypeWrapper>("/app/rest/buildTypes?locator=name:FluentTc"))
                 .Returns(new BuildTypeWrapper { BuildType = new List<BuildConfiguration>(new[] { new BuildConfiguration { Id = "bt987" } }) });
 

--- a/FluentTc.Tests/AcceptanceTests.cs
+++ b/FluentTc.Tests/AcceptanceTests.cs
@@ -543,7 +543,11 @@ namespace FluentTc.Tests
             var build = connectedTc.RunBuildConfiguration(having);
 
             // Assert
-            build.Id.Should().Be(123);
+            A.CallTo(() =>
+                teamCityCaller.PostFormat<BuildModel>("<build>\r\n<buildType id=\"bt2\"/>\r\n</build>\r\n",
+                    HttpContentTypes.ApplicationXml, HttpContentTypes.ApplicationJson, "/app/rest/buildQueue", A<object[]>.Ignored))
+                .MustHaveHappened(Repeated.Exactly.Once);
+            build.Should().NotBe(null);
             build.Id.ShouldBeEquivalentTo(123);
             build.Status.ShouldBeEquivalentTo(BuildStatus.Success);
         }

--- a/FluentTc.Tests/AcceptanceTests.cs
+++ b/FluentTc.Tests/AcceptanceTests.cs
@@ -221,13 +221,13 @@ namespace FluentTc.Tests
             var connectedTc = new RemoteTc().Connect(_ => _.AsGuest(), teamCityCaller, buildConfigurationRetriever);
 
             // Act
-            connectedTc.RunBuildConfiguration(having, options => options.WithComment("comment!"));
+            var build = connectedTc.RunBuildConfiguration(having, options => options.WithComment("comment!"));
 
             // Assert
             A.CallTo(
                 () =>
-                    teamCityCaller.Post("<build>\r\n<buildType id=\"bt2\"/>\r\n<comment><text>comment!</text></comment>\r\n</build>\r\n",
-                    HttpContentTypes.ApplicationXml, "/app/rest/buildQueue", ""))
+                    teamCityCaller.PostFormat<BuildModel>("<build>\r\n<buildType id=\"bt2\"/>\r\n<comment><text>comment!</text></comment>\r\n</build>\r\n",
+                    HttpContentTypes.ApplicationXml, HttpContentTypes.ApplicationJson, "/app/rest/buildQueue"))
                         .MustHaveHappened(Repeated.Exactly.Once);
         }
         
@@ -245,13 +245,13 @@ namespace FluentTc.Tests
             var connectedTc = new RemoteTc().Connect(_ => _.AsGuest(), teamCityCaller, buildConfigurationRetriever);
 
             // Act
-            connectedTc.RunBuildConfiguration(having, options => options.WithComment("comment<HAHA>"));
+            var build = connectedTc.RunBuildConfiguration(having, options => options.WithComment("comment<HAHA>"));
 
             // Assert
             A.CallTo(
                 () =>
-                    teamCityCaller.Post("<build>\r\n<buildType id=\"bt2\"/>\r\n<comment><text>comment&lt;HAHA&gt;</text></comment>\r\n</build>\r\n",
-                    HttpContentTypes.ApplicationXml, "/app/rest/buildQueue", ""))
+                    teamCityCaller.PostFormat<BuildModel>("<build>\r\n<buildType id=\"bt2\"/>\r\n<comment><text>comment&lt;HAHA&gt;</text></comment>\r\n</build>\r\n",
+                    HttpContentTypes.ApplicationXml, HttpContentTypes.ApplicationJson, "/app/rest/buildQueue"))
                         .MustHaveHappened(Repeated.Exactly.Once);
         }
 
@@ -269,13 +269,13 @@ namespace FluentTc.Tests
             var connectedTc = new RemoteTc().Connect(_ => _.AsGuest(), teamCityCaller, buildConfigurationRetriever);
 
             // Act
-            connectedTc.RunBuildConfiguration(having, options => options.WithComment("comment!").AsPersonal());
+            var build = connectedTc.RunBuildConfiguration(having, options => options.WithComment("comment!").AsPersonal());
 
             // Assert
             A.CallTo(
                 () =>
-                    teamCityCaller.Post("<build personal=\"true\">\r\n<buildType id=\"bt2\"/>\r\n<comment><text>comment!</text></comment>\r\n</build>\r\n",
-                    HttpContentTypes.ApplicationXml, "/app/rest/buildQueue", ""))
+                    teamCityCaller.PostFormat<BuildModel>("<build personal=\"true\">\r\n<buildType id=\"bt2\"/>\r\n<comment><text>comment!</text></comment>\r\n</build>\r\n",
+                    HttpContentTypes.ApplicationXml, HttpContentTypes.ApplicationJson, "/app/rest/buildQueue"))
                         .MustHaveHappened(Repeated.Exactly.Once);
         }
 
@@ -293,13 +293,13 @@ namespace FluentTc.Tests
             var connectedTc = new RemoteTc().Connect(_ => _.AsGuest(), teamCityCaller, buildConfigurationRetriever);
 
             // Act
-            connectedTc.RunBuildConfiguration(having, options => options.WithComment("comment!").AsPersonal().WithCleanSources());
+            var build = connectedTc.RunBuildConfiguration(having, options => options.WithComment("comment!").AsPersonal().WithCleanSources());
 
             // Assert
             A.CallTo(
                 () =>
-                    teamCityCaller.Post("<build personal=\"true\">\r\n<buildType id=\"bt2\"/>\r\n<comment><text>comment!</text></comment>\r\n<triggeringOptions cleanSources=\"true\" />\r\n</build>\r\n",
-                    HttpContentTypes.ApplicationXml, "/app/rest/buildQueue", ""))
+                    teamCityCaller.PostFormat<BuildModel>("<build personal=\"true\">\r\n<buildType id=\"bt2\"/>\r\n<comment><text>comment!</text></comment>\r\n<triggeringOptions cleanSources=\"true\" />\r\n</build>\r\n",
+                    HttpContentTypes.ApplicationXml, HttpContentTypes.ApplicationJson, "/app/rest/buildQueue"))
                         .MustHaveHappened(Repeated.Exactly.Once);
         }
 
@@ -317,13 +317,13 @@ namespace FluentTc.Tests
             var connectedTc = new RemoteTc().Connect(_ => _.AsGuest(), teamCityCaller, buildConfigurationRetriever);
 
             // Act
-            connectedTc.RunBuildConfiguration(having, options => options.WithCleanSources().QueueAtTop());
+            var build = connectedTc.RunBuildConfiguration(having, options => options.WithCleanSources().QueueAtTop());
 
             // Assert
             A.CallTo(
                 () =>
-                    teamCityCaller.Post("<build>\r\n<buildType id=\"bt2\"/>\r\n<triggeringOptions cleanSources=\"true\" queueAtTop=\"true\" />\r\n</build>\r\n",
-                    HttpContentTypes.ApplicationXml, "/app/rest/buildQueue", ""))
+                    teamCityCaller.PostFormat<BuildModel>("<build>\r\n<buildType id=\"bt2\"/>\r\n<triggeringOptions cleanSources=\"true\" queueAtTop=\"true\" />\r\n</build>\r\n",
+                    HttpContentTypes.ApplicationXml, HttpContentTypes.ApplicationJson, "/app/rest/buildQueue"))
                         .MustHaveHappened(Repeated.Exactly.Once);
         }
 
@@ -341,13 +341,13 @@ namespace FluentTc.Tests
             var connectedTc = new RemoteTc().Connect(_ => _.AsGuest(), teamCityCaller, buildConfigurationRetriever);
 
             // Act
-            connectedTc.RunBuildConfiguration(having);
+            var build = connectedTc.RunBuildConfiguration(having);
 
             // Assert
             A.CallTo(
                 () =>
-                    teamCityCaller.Post("<build>\r\n<buildType id=\"bt2\"/>\r\n</build>\r\n",
-                    HttpContentTypes.ApplicationXml, A<string>.Ignored, A<string>.Ignored))
+                    teamCityCaller.PostFormat<BuildModel>("<build>\r\n<buildType id=\"bt2\"/>\r\n</build>\r\n",
+                    HttpContentTypes.ApplicationXml, HttpContentTypes.ApplicationJson, A<string>.Ignored, A<object[]>.Ignored))
                         .MustHaveHappened(Repeated.Exactly.Once);
         }
 
@@ -364,13 +364,13 @@ namespace FluentTc.Tests
             var connectedTc = new RemoteTc().Connect(_ => _.AsGuest(), teamCityCaller, buildConfigurationRetriever);
 
             // Act
-            connectedTc.RunBuildConfiguration(having);
+            var build = connectedTc.RunBuildConfiguration(having);
 
             // Assert
             A.CallTo(
                 () =>
-                    teamCityCaller.Post("<build>\r\n<buildType id=\"bt2\"/>\r\n</build>\r\n",
-                    HttpContentTypes.ApplicationXml, "/app/rest/buildQueue", A<string>.Ignored))
+                    teamCityCaller.PostFormat<BuildModel>("<build>\r\n<buildType id=\"bt2\"/>\r\n</build>\r\n",
+                    HttpContentTypes.ApplicationXml, HttpContentTypes.ApplicationJson, "/app/rest/buildQueue", A<object[]>.Ignored))
                         .MustHaveHappened(Repeated.Exactly.Once);
         }
 
@@ -387,13 +387,13 @@ namespace FluentTc.Tests
             var connectedTc = new RemoteTc().Connect(_ => _.AsGuest(), teamCityCaller, buildConfigurationRetriever);
 
             // Act
-            connectedTc.RunBuildConfiguration(having, p => p.Parameter("param1","value1"));
+            var build = connectedTc.RunBuildConfiguration(having, p => p.Parameter("param1","value1"));
 
             // Assert
             A.CallTo(
                 () =>
-                    teamCityCaller.Post("<build>\r\n<buildType id=\"bt2\"/>\r\n<properties>\r\n<property name=\"param1\" value=\"value1\"/>\r\n</properties>\r\n</build>\r\n",
-                    HttpContentTypes.ApplicationXml, "/app/rest/buildQueue", A<string>.Ignored))
+                    teamCityCaller.PostFormat<BuildModel>("<build>\r\n<buildType id=\"bt2\"/>\r\n<properties>\r\n<property name=\"param1\" value=\"value1\"/>\r\n</properties>\r\n</build>\r\n",
+                    HttpContentTypes.ApplicationXml, HttpContentTypes.ApplicationJson, "/app/rest/buildQueue", A<object[]>.Ignored))
                         .MustHaveHappened(Repeated.Exactly.Once);
         }
 
@@ -415,13 +415,13 @@ namespace FluentTc.Tests
             var connectedTc = new RemoteTc().Connect(_ => _.AsGuest(), teamCityCaller, buildConfigurationRetriever, agentsRetriever);
 
             // Act
-            connectedTc.RunBuildConfiguration(having, onAgent);
+            var build = connectedTc.RunBuildConfiguration(having, onAgent);
 
             // Assert
             A.CallTo(
                 () =>
-                    teamCityCaller.Post("<build>\r\n<buildType id=\"bt2\"/>\r\n<agent id=\"9\"/>\r\n</build>\r\n",
-                    HttpContentTypes.ApplicationXml, "/app/rest/buildQueue", A<string>.Ignored))
+                    teamCityCaller.PostFormat<BuildModel>("<build>\r\n<buildType id=\"bt2\"/>\r\n<agent id=\"9\"/>\r\n</build>\r\n",
+                    HttpContentTypes.ApplicationXml, HttpContentTypes.ApplicationJson, "/app/rest/buildQueue", A<object[]>.Ignored))
                         .MustHaveHappened(Repeated.Exactly.Once);
         }
 
@@ -442,13 +442,13 @@ namespace FluentTc.Tests
             var connectedTc = new RemoteTc().Connect(_ => _.AsGuest(), teamCityCaller, buildConfigurationRetriever, agentsRetriever);
 
             // Act
-            connectedTc.RunBuildConfiguration(having, onAgent, p => p.Parameter("param1", "value1"));
+            var build = connectedTc.RunBuildConfiguration(having, onAgent, p => p.Parameter("param1", "value1"));
 
             // Assert
             A.CallTo(
                 () =>
-                    teamCityCaller.Post("<build>\r\n<buildType id=\"bt2\"/>\r\n<agent id=\"9\"/>\r\n<properties>\r\n<property name=\"param1\" value=\"value1\"/>\r\n</properties>\r\n</build>\r\n",
-                    HttpContentTypes.ApplicationXml, "/app/rest/buildQueue", A<string>.Ignored))
+                    teamCityCaller.PostFormat<BuildModel>("<build>\r\n<buildType id=\"bt2\"/>\r\n<agent id=\"9\"/>\r\n<properties>\r\n<property name=\"param1\" value=\"value1\"/>\r\n</properties>\r\n</build>\r\n",
+                    HttpContentTypes.ApplicationXml, HttpContentTypes.ApplicationJson, "/app/rest/buildQueue", A<object[]>.Ignored))
                         .MustHaveHappened(Repeated.Exactly.Once);
         }
 

--- a/FluentTc.Tests/AcceptanceTests.cs
+++ b/FluentTc.Tests/AcceptanceTests.cs
@@ -553,6 +553,33 @@ namespace FluentTc.Tests
         }
 
         [Test]
+        public void RunBuildConfiguration_BuildResponse_WithParameters()
+        {
+            // Arrange
+            Action<IBuildConfigurationHavingBuilder> having = _ => _.Id("FluentTc");
+            var teamCityCaller = CreateTeamCityCaller();
+            var buildConfigurationRetriever = A.Fake<IBuildConfigurationRetriever>();
+
+            A.CallTo(() => buildConfigurationRetriever.GetSingleBuildConfiguration(having))
+                .Returns(new BuildConfiguration { Id = "bt2" });
+            A.CallTo(() =>
+                teamCityCaller.PostFormat<BuildModel>(
+                    "<build>\r\n<buildType id=\"bt2\"/>\r\n<properties>\r\n<property name=\"param1\" value=\"value1\"/>\r\n</properties>\r\n</build>\r\n",
+                    HttpContentTypes.ApplicationXml, HttpContentTypes.ApplicationJson, "/app/rest/buildQueue", A<object[]>.Ignored))
+                .Returns(new BuildModel {Id = 123, Status = "SUCCESS"});
+
+            var connectedTc = new RemoteTc().Connect(_ => _.AsGuest(), teamCityCaller, buildConfigurationRetriever);
+
+            // Act
+            var build = connectedTc.RunBuildConfiguration(having, p => p.Parameter("param1", "value1"));
+
+            // Assert
+            build.Should().NotBe(null);
+            build.Id.ShouldBeEquivalentTo(123);
+            build.Status.ShouldBeEquivalentTo(BuildStatus.Success);
+        }
+
+        [Test]
         public void GetBuildConfigurations_ByName()
         {
             // Arrange

--- a/FluentTc.Tests/ConnectedTcTests.cs
+++ b/FluentTc.Tests/ConnectedTcTests.cs
@@ -208,5 +208,20 @@ namespace FluentTc.Tests
             buildStatistics.Single().Name.Should().Be("TestName");
             buildStatistics.Single().Value.Should().Be("TestValue");
         }
+
+        [Test]
+        public void RunBuildConfiguration_BuildResponse()
+        {
+            // Arrange
+            Action<IBuildConfigurationHavingBuilder> having = _ => _.Name("FluentTc");
+            var fixture = Auto.Fixture();
+            var connectedTc = fixture.Create<ConnectedTc>();
+
+            // Act
+            var build = connectedTc.RunBuildConfiguration(having);
+
+            // Assert
+            build.Should().NotBe(null);
+        }
     }
 }

--- a/FluentTc.Tests/Engine/BuildModelToBuildConverterTests.cs
+++ b/FluentTc.Tests/Engine/BuildModelToBuildConverterTests.cs
@@ -93,5 +93,22 @@ namespace FluentTc.Tests.Engine
             builds.Single().Status.HasValue.Should().BeFalse();
             builds.Single().BuildConfiguration.Id.Should().Be("bt2");
         }
+
+        [Test]
+        public void ConvertToBuild()
+        {
+            var buildModelToBuildConverter = new BuildModelToBuildConverter();
+            var buildModel = new BuildModel
+            {
+                Status = "FAILURE",
+                BuildType = new BuildConfiguration {Id = "bt2"},
+                BuildTypeId = "bt2"
+            };
+            var build = buildModelToBuildConverter.ConvertToBuild(buildModel);
+
+            // Assert
+            build.Status.Should().Be(BuildStatus.Failure);
+            build.BuildConfiguration.Id.Should().Be("bt2");
+        }
     }
 }

--- a/FluentTc.Tests/RemoteTcTests.cs
+++ b/FluentTc.Tests/RemoteTcTests.cs
@@ -98,17 +98,17 @@ namespace FluentTc.Tests
                 .SetBuildConfigurationParameters(_ => _.Id("bt2"),
                     _ => _.Parameter("name", "value").Parameter("name2", "value"));
 
-            new RemoteTc().Connect(_ => _.ToHost("tc"))
+            build = new RemoteTc().Connect(_ => _.ToHost("tc"))
                 .RunBuildConfiguration(_ => _.Id("bt2"));
 
-            new RemoteTc().Connect(_ => _.ToHost("tc"))
+            build = new RemoteTc().Connect(_ => _.ToHost("tc"))
                 .RunBuildConfiguration(_ => _.Id("bt2"),
                     _ => _.Parameter("name", "value").Parameter("name2", "value"));
 
-            new RemoteTc().Connect(_ => _.ToHost("tc"))
+            build = new RemoteTc().Connect(_ => _.ToHost("tc"))
                 .RunBuildConfiguration(having => having.Id("bt2"), onAgent => onAgent.Name("agent1"));
 
-            new RemoteTc().Connect(_ => _.ToHost("tc"))
+            build = new RemoteTc().Connect(_ => _.ToHost("tc"))
                 .RunBuildConfiguration(_ => _.Id("bt2"), _ => _.Name("agent1"),
                     _ => _.Parameter("name", "value").Parameter("name2", "value"));
 

--- a/FluentTc/ConnectedTc.cs
+++ b/FluentTc/ConnectedTc.cs
@@ -95,17 +95,17 @@ namespace FluentTc
             Action<IBuildParameterValueBuilder> parameters);
         void SetProjectParameters(Action<IBuildProjectHavingBuilder> having, Action<IBuildParameterValueBuilder> parameters);
 
-        void RunBuildConfiguration(Action<IBuildConfigurationHavingBuilder> having,
+        IBuild RunBuildConfiguration(Action<IBuildConfigurationHavingBuilder> having,
             Action<IBuildParameterValueBuilder> parameters);
 
-        void RunBuildConfiguration(Action<IBuildConfigurationHavingBuilder> having, Action<IAgentHavingBuilder> onAgent);
+        IBuild RunBuildConfiguration(Action<IBuildConfigurationHavingBuilder> having, Action<IAgentHavingBuilder> onAgent);
 
-        void RunBuildConfiguration(Action<IBuildConfigurationHavingBuilder> having, Action<IAgentHavingBuilder> onAgent,
+        IBuild RunBuildConfiguration(Action<IBuildConfigurationHavingBuilder> having, Action<IAgentHavingBuilder> onAgent,
             Action<IBuildParameterValueBuilder> parameters);
 
-        void RunBuildConfiguration(Action<IBuildConfigurationHavingBuilder> having);
+        IBuild RunBuildConfiguration(Action<IBuildConfigurationHavingBuilder> having);
 
-        void RunBuildConfiguration(Action<IBuildConfigurationHavingBuilder> having, Action<IMoreOptionsHavingBuilder> moreOptions);
+        IBuild RunBuildConfiguration(Action<IBuildConfigurationHavingBuilder> having, Action<IMoreOptionsHavingBuilder> moreOptions);
 
         BuildConfiguration CreateBuildConfiguration(Action<IBuildProjectHavingBuilder> having,
             string buildConfigurationName);
@@ -289,32 +289,32 @@ namespace FluentTc
             m_ProjectPropertySetter.SetProjectParameters(having, parameters);
         }
 
-        public void RunBuildConfiguration(Action<IBuildConfigurationHavingBuilder> having,
+        public IBuild RunBuildConfiguration(Action<IBuildConfigurationHavingBuilder> having,
             Action<IBuildParameterValueBuilder> parameters)
         {
-            m_BuildConfigurationRunner.Run(having, parameters: parameters);
+            return m_BuildConfigurationRunner.Run(having, parameters: parameters);
         }
 
-        public void RunBuildConfiguration(Action<IBuildConfigurationHavingBuilder> having,
+        public IBuild RunBuildConfiguration(Action<IBuildConfigurationHavingBuilder> having,
             Action<IAgentHavingBuilder> onAgent)
         {
-            m_BuildConfigurationRunner.Run(having, onAgent);
+            return m_BuildConfigurationRunner.Run(having, onAgent);
         }
 
-        public void RunBuildConfiguration(Action<IBuildConfigurationHavingBuilder> having, Action<IMoreOptionsHavingBuilder> moreOptions)
+        public IBuild RunBuildConfiguration(Action<IBuildConfigurationHavingBuilder> having, Action<IMoreOptionsHavingBuilder> moreOptions)
         {
-            m_BuildConfigurationRunner.Run(having, moreOptions: moreOptions);
+            return m_BuildConfigurationRunner.Run(having, moreOptions: moreOptions);
         }
 
-        public void RunBuildConfiguration(Action<IBuildConfigurationHavingBuilder> having,
+        public IBuild RunBuildConfiguration(Action<IBuildConfigurationHavingBuilder> having,
             Action<IAgentHavingBuilder> onAgent, Action<IBuildParameterValueBuilder> parameters)
         {
-            m_BuildConfigurationRunner.Run(having, onAgent, parameters);
+            return m_BuildConfigurationRunner.Run(having, onAgent, parameters);
         }
 
-        public void RunBuildConfiguration(Action<IBuildConfigurationHavingBuilder> having)
+        public IBuild RunBuildConfiguration(Action<IBuildConfigurationHavingBuilder> having)
         {
-            m_BuildConfigurationRunner.Run(having);
+            return m_BuildConfigurationRunner.Run(having);
         }
 
         public BuildConfiguration CreateBuildConfiguration(Action<IBuildProjectHavingBuilder> having,


### PR DESCRIPTION
Need ability to get buildId on post buildQueue #71

### Checklist
- [x] All unit tests passed on build server
- [x] Acceptance test(s) covers new/modified functionality 
- [ ] Code coverage is at least the same or higher
- [x] Breaking change in public API

var connection = new RemoteTc().Connect(_ => _.ToHost("tc"));
build = connection.RunBuildConfiguration(having => having.Id("bt2"));
Thread.Sleep(10000);
var status = connection.GetBuild(build.Id).Status;