### PR TITLE
widen autofac version range to 3.5-5.0

### DIFF
--- a/FluentTc/FluentTc.nuspec
+++ b/FluentTc/FluentTc.nuspec
@@ -12,7 +12,7 @@
     <copyright>Copyright © 2015</copyright>
     <tags>TeamCity API REST HTTP</tags>
     <dependencies>
-      <dependency id="Autofac" version="[3.5.0,4.0.0)" />
+      <dependency id="Autofac" version="[3.5.0,5.0.0)" />
       <dependency id="EasyHttp" version="[1.6.85.0,2.0.0.0)" />
       <dependency id="SharpZipLib" version="0.86.0" />
       <dependency id="System.IO.Abstractions" version="[2.0.0.124,3.0.0.0)" />


### PR DESCRIPTION
### Issue details

widen autofac version range to 3.5-5.0


### Checklist
- [x] All unit tests passed on build server
- [ ] Acceptance test(s) covers new/modified functionality 
- [x] Code coverage is at least the same or higher
- [ ] Breaking change in public API

