### PR TITLE
Changes the spelling of "Cancelled" to "Canceled" (which TeamCity expects)

### DIFF
--- a/FluentTc.Tests/Locators/BuildHavingBuilderTests.cs
+++ b/FluentTc.Tests/Locators/BuildHavingBuilderTests.cs
@@ -74,7 +74,7 @@ namespace FluentTc.Tests.Locators
             buildHavingBuilder.Cancelled();
 
             // Assert
-            buildHavingBuilder.GetLocator().Should().Be("cancelled:True");
+            buildHavingBuilder.GetLocator().Should().Be("canceled:True");
         }
 
         [Test]
@@ -116,7 +116,7 @@ namespace FluentTc.Tests.Locators
             buildHavingBuilder.NotCancelled();
 
             // Assert
-            buildHavingBuilder.GetLocator().Should().Be("cancelled:False");
+            buildHavingBuilder.GetLocator().Should().Be("canceled:False");
         }
 
         [Test]

--- a/FluentTc/Locators/BuildHavingBuilder.cs
+++ b/FluentTc/Locators/BuildHavingBuilder.cs
@@ -105,13 +105,13 @@ namespace FluentTc.Locators
 
         public IBuildHavingBuilder Cancelled()
         {
-            m_Having.Add("cancelled:" + bool.TrueString);
+            m_Having.Add("canceled:" + bool.TrueString);
             return this;
         }
 
         public IBuildHavingBuilder NotCancelled()
         {
-            m_Having.Add("cancelled:" + bool.FalseString);
+            m_Having.Add("canceled:" + bool.FalseString);
             return this;
         }
 


### PR DESCRIPTION
### Issue details

Cancelled is spelt "correctly" in this code-base, but TeamCity expects the US version: "canceled" (_one L_)

### Relates to issue
Close #89 

### Checklist
- [x] All unit tests passed on build server
- [x] Acceptance test(s) covers new/modified functionality 
- [x] Code coverage is at least the same or higher
- [ ] Breaking change in public API

# Example of using new/modified functionality

```C#
        [Test]
        public void NotCancelled()
        {
            // Arrange
            var fixture = Auto.Fixture();
            var buildHavingBuilder = fixture.Create<BuildHavingBuilder>();

            // Act
            buildHavingBuilder.NotCancelled();

            // Assert
            buildHavingBuilder.GetLocator().Should().Be("canceled:False");
        }
```
