### PR TITLE
Add access to information on the source of an artifact dependency

### DIFF
--- a/FluentTc.Tests/AcceptanceTests.cs
+++ b/FluentTc.Tests/AcceptanceTests.cs
@@ -699,8 +699,35 @@ namespace FluentTc.Tests
             var teamCityCaller = CreateTeamCityCaller();
             A.CallTo(() => teamCityCaller.Get<BuildTypeWrapper>("/app/rest/buildTypes?locator=id:bt123"))
                 .Returns(new BuildTypeWrapper { BuildType = new List<BuildConfiguration>(new[] { new BuildConfiguration { Id = "bt123" } }) });
+            var buildConfigMock = new BuildConfiguration {
+                Id = "bt123",
+                SnapshotDependencies = new SnapshotDependencies
+                {
+                    SnapshotDependency = new List<SnapshotDependency>
+                    {
+                        new SnapshotDependency() { Id = "dep.bt123" }
+                    }
+                },
+                ArtifactDependencies = new ArtifactDependencies
+                {
+                    ArtifactDependency = new List<ArtifactDependency>
+                    {
+                        new ArtifactDependency()
+                        {
+                            Id = "ARTIFACT_DEPENDENCY_1",
+                            SourceBuildType = new SourceBuildType()
+                            {
+                                Id = "buildConfig123",
+                                Name = "Build Config 123",
+                                ProjectId = "proj123",
+                                ProjectName = "Project 123"
+                            }    
+                        }
+                    }
+                }
+            };
             A.CallTo(() => teamCityCaller.Get<BuildConfiguration>("/app/rest/buildTypes/id:bt123"))
-                .Returns(new BuildConfiguration { Id = "bt123", SnapshotDependencies = new SnapshotDependencies { SnapshotDependency = new List<SnapshotDependency>(new[] { new SnapshotDependency() { Id = "dep.bt123" } }) } });
+                .Returns(buildConfigMock);
 
             var connectedTc = new RemoteTc().Connect(_ => _.AsGuest(), teamCityCaller);
 
@@ -709,6 +736,12 @@ namespace FluentTc.Tests
 
             // Assert
             buildConfiguration.SnapshotDependencies.SnapshotDependency.Single().Id.Should().Be("dep.bt123");
+            var artifactDependency = buildConfiguration.ArtifactDependencies.ArtifactDependency.Single();
+            artifactDependency.Id.Should().Be("ARTIFACT_DEPENDENCY_1");
+            artifactDependency.SourceBuildType.Id.Should().Be("buildConfig123");
+            artifactDependency.SourceBuildType.Name.Should().Be("Build Config 123");
+            artifactDependency.SourceBuildType.ProjectId.Should().Be("proj123");
+            artifactDependency.SourceBuildType.ProjectName.Should().Be("Project 123");
         }
 
         [Test]

--- a/FluentTc/Domain/ArtifactDependency.cs
+++ b/FluentTc/Domain/ArtifactDependency.cs
@@ -1,5 +1,7 @@
 namespace FluentTc.Domain
 {
+    using JsonFx.Json;
+
     public class ArtifactDependency
     {
         public override string ToString()
@@ -8,7 +10,12 @@ namespace FluentTc.Domain
         }
 
         public string Id { get; set; }
+
         public string Type { get; set; }
+
         public Properties Properties { get; set; }
+
+        [JsonName("source-buildType")]
+        public SourceBuildType SourceBuildType { get; set; }
     }
 }

--- a/FluentTc/Domain/SourceBuildType.cs
+++ b/FluentTc/Domain/SourceBuildType.cs
@@ -1,0 +1,15 @@
+﻿namespace FluentTc.Domain
+{
+    public class SourceBuildType
+    {
+        public override string ToString()
+        {
+            return "source-buildType";
+        }
+
+        public string Id { get; set; }
+        public string Name { get; set; }
+        public string ProjectName { get; set; }
+        public string ProjectId { get; set; }
+    }
+}

--- a/FluentTc/FluentTc.csproj
+++ b/FluentTc/FluentTc.csproj
@@ -69,6 +69,7 @@
   <ItemGroup>
     <Compile Include="Domain\RevisionsList.cs" />
     <Compile Include="Domain\RevisionsWrapper.cs" />
+    <Compile Include="Domain\SourceBuildType.cs" />
     <Compile Include="Domain\TestOccurrences.cs" />
     <Compile Include="Locators\BuildState.cs" />
     <Compile Include="Locators\MoreOptionsHavingBuilder.cs" />


### PR DESCRIPTION
The ArtifactDependency class did not include information on the source build configuration of the dependency. This information is provided in the REST API in the "source-buildType" object.

I have added a new class SourceBuildType and added a corresponding property to the ArtifactDependency class. Now the build config information is automatically deserialized by EasyHttp.