### PR TITLE
Allowing to chose branch when triggering build

### DIFF
--- a/FluentTc.Tests/AcceptanceTests.cs
+++ b/FluentTc.Tests/AcceptanceTests.cs
@@ -653,6 +653,37 @@ namespace FluentTc.Tests
         }
 
         [Test]
+        public void RunBuildConfiguration_BranchNameWithCharactersRequiringEscaping()
+        {
+            // Arrange
+            Action<IBuildConfigurationHavingBuilder> having = _ => _.Name("FluentTc");
+            var teamCityCaller = CreateTeamCityCaller();
+            var buildConfigurationRetriever = A.Fake<IBuildConfigurationRetriever>();
+
+            A.CallTo(() => buildConfigurationRetriever.GetSingleBuildConfiguration(having))
+                .Returns(new BuildConfiguration { Id = "bt2" });
+            A.CallTo(() =>
+                teamCityCaller.PostFormat<BuildModel>(
+                    "<build branchName=\"r&amp;d\">\r\n<buildType id=\"bt2\"/>\r\n</build>\r\n",
+                    HttpContentTypes.ApplicationXml, HttpContentTypes.ApplicationJson, "/app/rest/buildQueue"))
+                .Returns(new BuildModel { Id = 123, Status = "SUCCESS" });
+
+            var connectedTc = new RemoteTc().Connect(_ => _.AsGuest(), teamCityCaller, buildConfigurationRetriever);
+
+            // Act
+            var build = connectedTc.RunBuildConfiguration(having, o => o.OnBranch("r&d"));
+
+            // Assert
+            A.CallTo(() =>
+                teamCityCaller.PostFormat<BuildModel>(
+                    "<build branchName=\"r&amp;d\">\r\n<buildType id=\"bt2\"/>\r\n</build>\r\n",
+                    HttpContentTypes.ApplicationXml, HttpContentTypes.ApplicationJson, A<string>.Ignored, A<object[]>.Ignored))
+                .MustHaveHappened(Repeated.Exactly.Once);
+            build.Id.ShouldBeEquivalentTo(123);
+            build.Status.ShouldBeEquivalentTo(BuildStatus.Success);
+        }
+
+        [Test]
         public void RunBuildConfiguration_BuildResponse()
         {
             // Arrange

--- a/FluentTc.Tests/AcceptanceTests.cs
+++ b/FluentTc.Tests/AcceptanceTests.cs
@@ -591,6 +591,68 @@ namespace FluentTc.Tests
         }
 
         [Test]
+        public void RunBuildConfiguration_BranchName()
+        {
+            // Arrange
+            Action<IBuildConfigurationHavingBuilder> having = _ => _.Name("FluentTc");
+            var teamCityCaller = CreateTeamCityCaller();
+            var buildConfigurationRetriever = A.Fake<IBuildConfigurationRetriever>();
+
+            A.CallTo(() => buildConfigurationRetriever.GetSingleBuildConfiguration(having))
+                .Returns(new BuildConfiguration { Id = "bt2" });
+            A.CallTo(() =>
+                teamCityCaller.PostFormat<BuildModel>(
+                    "<build branchName=\"develop\">\r\n<buildType id=\"bt2\"/>\r\n</build>\r\n",
+                    HttpContentTypes.ApplicationXml, HttpContentTypes.ApplicationJson, "/app/rest/buildQueue"))
+                .Returns(new BuildModel { Id = 123, Status = "SUCCESS" });
+
+            var connectedTc = new RemoteTc().Connect(_ => _.AsGuest(), teamCityCaller, buildConfigurationRetriever);
+
+            // Act
+            var build = connectedTc.RunBuildConfiguration(having, o => o.BranchName("develop"));
+
+            // Assert
+            A.CallTo(() =>
+                teamCityCaller.PostFormat<BuildModel>(
+                    "<build branchName=\"develop\">\r\n<buildType id=\"bt2\"/>\r\n</build>\r\n",
+                    HttpContentTypes.ApplicationXml, HttpContentTypes.ApplicationJson, A<string>.Ignored, A<object[]>.Ignored))
+                .MustHaveHappened(Repeated.Exactly.Once);
+            build.Id.ShouldBeEquivalentTo(123);
+            build.Status.ShouldBeEquivalentTo(BuildStatus.Success);
+        }
+
+        [Test]
+        public void RunBuildConfiguration_BranchNameAndPersonal()
+        {
+            // Arrange
+            Action<IBuildConfigurationHavingBuilder> having = _ => _.Name("FluentTc");
+            var teamCityCaller = CreateTeamCityCaller();
+            var buildConfigurationRetriever = A.Fake<IBuildConfigurationRetriever>();
+
+            A.CallTo(() => buildConfigurationRetriever.GetSingleBuildConfiguration(having))
+                .Returns(new BuildConfiguration { Id = "bt2" });
+            A.CallTo(() =>
+                teamCityCaller.PostFormat<BuildModel>(
+                    "<build personal=\"true\" branchName=\"develop\">\r\n<buildType id=\"bt2\"/>\r\n</build>\r\n",
+                    HttpContentTypes.ApplicationXml, HttpContentTypes.ApplicationJson, "/app/rest/buildQueue"))
+                .Returns(new BuildModel { Id = 123, Status = "SUCCESS" });
+
+            var connectedTc = new RemoteTc().Connect(_ => _.AsGuest(), teamCityCaller, buildConfigurationRetriever);
+
+            // Act
+            var build = connectedTc.RunBuildConfiguration(having, o => o.BranchName("develop").AsPersonal());
+
+            // Assert
+            A.CallTo(() =>
+                teamCityCaller.PostFormat<BuildModel>(
+                    "<build personal=\"true\" branchName=\"develop\">\r\n<buildType id=\"bt2\"/>\r\n</build>\r\n",
+                    HttpContentTypes.ApplicationXml, HttpContentTypes.ApplicationJson, A<string>.Ignored, A<object[]>.Ignored))
+                .MustHaveHappened(Repeated.Exactly.Once);
+            build.Id.ShouldBeEquivalentTo(123);
+            build.Status.ShouldBeEquivalentTo(BuildStatus.Success);
+        }
+
+        [Test]
         public void RunBuildConfiguration_BuildResponse()
         {
             // Arrange

--- a/FluentTc.Tests/AcceptanceTests.cs
+++ b/FluentTc.Tests/AcceptanceTests.cs
@@ -609,7 +609,7 @@ namespace FluentTc.Tests
             var connectedTc = new RemoteTc().Connect(_ => _.AsGuest(), teamCityCaller, buildConfigurationRetriever);
 
             // Act
-            var build = connectedTc.RunBuildConfiguration(having, o => o.BranchName("develop"));
+            var build = connectedTc.RunBuildConfiguration(having, o => o.OnBranch("develop"));
 
             // Assert
             A.CallTo(() =>
@@ -640,7 +640,7 @@ namespace FluentTc.Tests
             var connectedTc = new RemoteTc().Connect(_ => _.AsGuest(), teamCityCaller, buildConfigurationRetriever);
 
             // Act
-            var build = connectedTc.RunBuildConfiguration(having, o => o.BranchName("develop").AsPersonal());
+            var build = connectedTc.RunBuildConfiguration(having, o => o.OnBranch("develop").AsPersonal());
 
             // Assert
             A.CallTo(() =>

--- a/FluentTc/Engine/BuildConfigurationRunner.cs
+++ b/FluentTc/Engine/BuildConfigurationRunner.cs
@@ -76,16 +76,24 @@ namespace FluentTc.Engine
         {
             var bodyBuilder = new StringBuilder();
 
-            if (moreOptions != null &&
-                moreOptions.TriggeringOptions.Personal == true)
+            bodyBuilder.Append(@"<build");
+
+            if (moreOptions != null)
             {
-                bodyBuilder.Append(@"<build personal=""true"">").AppendLine();
+                if (moreOptions.TriggeringOptions.Personal == true)
+                {
+                    bodyBuilder.Append(@" personal=""true""");
+                }
+
+                if (moreOptions.GetBranchName() != null)
+                {
+                    var encodedName = SecurityElement.Escape(moreOptions.GetBranchName());
+                    bodyBuilder.AppendFormat(@" branchName=""{0}""", encodedName);
+                }
             }
-            else
-            {
-                bodyBuilder.Append(@"<build>").AppendLine();
-            }
-            
+
+            bodyBuilder.Append(@">").AppendLine();
+
             bodyBuilder.AppendFormat(@"<buildType id=""{0}""/>", buildConfigId).AppendLine();
 
             if (agentId.HasValue)

--- a/FluentTc/Engine/BuildConfigurationRunner.cs
+++ b/FluentTc/Engine/BuildConfigurationRunner.cs
@@ -85,7 +85,7 @@ namespace FluentTc.Engine
                     bodyBuilder.Append(@" personal=""true""");
                 }
 
-                if (moreOptions.GetBranchName() != null)
+                if (moreOptions.HasBranch())
                 {
                     var encodedName = SecurityElement.Escape(moreOptions.GetBranchName());
                     bodyBuilder.AppendFormat(@" branchName=""{0}""", encodedName);

--- a/FluentTc/Locators/MoreOptionsHavingBuilder.cs
+++ b/FluentTc/Locators/MoreOptionsHavingBuilder.cs
@@ -70,6 +70,11 @@ namespace FluentTc.Locators
             return m_BranchName;
         }
 
+        public bool HasBranch()
+        {
+            return !string.IsNullOrEmpty(m_BranchName);
+        }
+
         public TriggeringOptions TriggeringOptions
         {
             get { return m_TriggeringOptions; }

--- a/FluentTc/Locators/MoreOptionsHavingBuilder.cs
+++ b/FluentTc/Locators/MoreOptionsHavingBuilder.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Xml;
 
 namespace FluentTc.Locators
 {
@@ -11,11 +9,13 @@ namespace FluentTc.Locators
         IMoreOptionsHavingBuilder QueueAtTop();
         IMoreOptionsHavingBuilder AsPersonal();
         IMoreOptionsHavingBuilder WithComment(string comment);
+        IMoreOptionsHavingBuilder BranchName(string branchName);
     }
 
     internal class MoreOptionsHavingBuilder : IMoreOptionsHavingBuilder
     {
         private string m_Comment;
+        private string m_BranchName;
         private readonly TriggeringOptions m_TriggeringOptions;
 
         public MoreOptionsHavingBuilder()
@@ -56,9 +56,20 @@ namespace FluentTc.Locators
             return this;
         }
 
+        public IMoreOptionsHavingBuilder BranchName(string branchName)
+        {
+            m_BranchName = branchName;
+            return this;
+        }
+
         public string GetComment()
         {
             return m_Comment;
+        }
+
+        public string GetBranchName()
+        {
+            return m_BranchName;
         }
 
         public TriggeringOptions TriggeringOptions

--- a/FluentTc/Locators/MoreOptionsHavingBuilder.cs
+++ b/FluentTc/Locators/MoreOptionsHavingBuilder.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace FluentTc.Locators
 {
     public interface IMoreOptionsHavingBuilder
@@ -9,7 +7,7 @@ namespace FluentTc.Locators
         IMoreOptionsHavingBuilder QueueAtTop();
         IMoreOptionsHavingBuilder AsPersonal();
         IMoreOptionsHavingBuilder WithComment(string comment);
-        IMoreOptionsHavingBuilder BranchName(string branchName);
+        IMoreOptionsHavingBuilder OnBranch(string branchName);
     }
 
     internal class MoreOptionsHavingBuilder : IMoreOptionsHavingBuilder
@@ -56,7 +54,7 @@ namespace FluentTc.Locators
             return this;
         }
 
-        public IMoreOptionsHavingBuilder BranchName(string branchName)
+        public IMoreOptionsHavingBuilder OnBranch(string branchName)
         {
             m_BranchName = branchName;
             return this;


### PR DESCRIPTION
### Issue details

In TeamCity we can create a build configuration that will automatically build pull requests from GitHub as described [here](https://blog.jetbrains.com/teamcity/2013/02/automatically-building-pull-requests-from-github-with-teamcity/) (in latest TC you can use build feature _Commit status publisher_). The problem is this build relies on non-default branches and we can't use FluentTc to manually trigger them as we can't specify which branch should be used. This small fix allows to specify this branch.

### Relates to issue

None

### Checklist
- [x] All unit tests passed on build server
- [x] Acceptance test(s) covers new/modified functionality 
- [x] Code coverage is at least the same or higher
- [x] Breaking change in public API

# Example of using new/modified functionality

```C#
public void RunGitHubPullRequest(string pullRequestId)
{ 
    new RemoteTc()
        .Connect(_ => _.ToHost(TeamCityHost).AsUser(Username, Password))
        .RunBuildConfiguration(_ => _.Id("PullRequests"), _ => _.BranchName(pullRequestId));
}

...

RunGitHubPullRequest("12");
```
