### PR TITLE
Added SourceBuildType property to SnapshotDependency. Extended set of…

### DIFF
--- a/FluentTc.Tests/AcceptanceTests.cs
+++ b/FluentTc.Tests/AcceptanceTests.cs
@@ -833,7 +833,19 @@ namespace FluentTc.Tests
                 {
                     SnapshotDependency = new List<SnapshotDependency>
                     {
-                        new SnapshotDependency() { Id = "dep.bt123" }
+                        new SnapshotDependency
+                        {
+                            Id = "SpanshotDepId",
+                            SourceBuildType = new SourceBuildType()
+                            {
+                                Id = "SnapshotDepBuildConfig",
+                                Name = "Snapshot Dep Build Config 123",
+                                Href = "/httpAuth/app/rest/buildTypes/id:SnapshotDepBuildConfig",
+                                WebUrl = "http://teamcity/viewType.html?buildTypeId=SnapshotDepBuildConfig",
+                                ProjectId = "SnapshotDepProj123",
+                                ProjectName = "SnapshotDep Project 123"
+                            }
+                        }
                     }
                 },
                 ArtifactDependencies = new ArtifactDependencies
@@ -845,10 +857,12 @@ namespace FluentTc.Tests
                             Id = "ARTIFACT_DEPENDENCY_1",
                             SourceBuildType = new SourceBuildType()
                             {
-                                Id = "buildConfig123",
-                                Name = "Build Config 123",
-                                ProjectId = "proj123",
-                                ProjectName = "Project 123"
+                                Id = "ArtifactDepBuildConfig123",
+                                Name = "Artifact Dep Build Config 123",
+                                Href = "/httpAuth/app/rest/buildTypes/id:ArtifactDepBuildConfig123",
+                                WebUrl = "http://teamcity/viewType.html?buildTypeId=ArtifactDepBuildConfig123",
+                                ProjectId = "ArtifactDepProj123",
+                                ProjectName = "ArtifactDep Project 123"
                             }    
                         }
                     }
@@ -863,13 +877,23 @@ namespace FluentTc.Tests
             var buildConfiguration = connectedTc.GetBuildConfiguration(_ => _.Id("bt123"));
 
             // Assert
-            buildConfiguration.SnapshotDependencies.SnapshotDependency.Single().Id.Should().Be("dep.bt123");
+            var snapshotDependency = buildConfiguration.SnapshotDependencies.SnapshotDependency.Single();
+            snapshotDependency.Id.Should().Be("SpanshotDepId");
+            snapshotDependency.SourceBuildType.Id.Should().Be("SnapshotDepBuildConfig");
+            snapshotDependency.SourceBuildType.Name.Should().Be("Snapshot Dep Build Config 123");
+            snapshotDependency.SourceBuildType.Href.Should().Be("/httpAuth/app/rest/buildTypes/id:SnapshotDepBuildConfig");
+            snapshotDependency.SourceBuildType.WebUrl.Should().Be("http://teamcity/viewType.html?buildTypeId=SnapshotDepBuildConfig");
+            snapshotDependency.SourceBuildType.ProjectId.Should().Be("SnapshotDepProj123");
+            snapshotDependency.SourceBuildType.ProjectName.Should().Be("SnapshotDep Project 123");
+
             var artifactDependency = buildConfiguration.ArtifactDependencies.ArtifactDependency.Single();
             artifactDependency.Id.Should().Be("ARTIFACT_DEPENDENCY_1");
-            artifactDependency.SourceBuildType.Id.Should().Be("buildConfig123");
-            artifactDependency.SourceBuildType.Name.Should().Be("Build Config 123");
-            artifactDependency.SourceBuildType.ProjectId.Should().Be("proj123");
-            artifactDependency.SourceBuildType.ProjectName.Should().Be("Project 123");
+            artifactDependency.SourceBuildType.Id.Should().Be("ArtifactDepBuildConfig123");
+            artifactDependency.SourceBuildType.Name.Should().Be("Artifact Dep Build Config 123");
+            artifactDependency.SourceBuildType.Href.Should().Be("/httpAuth/app/rest/buildTypes/id:ArtifactDepBuildConfig123");
+            artifactDependency.SourceBuildType.WebUrl.Should().Be("http://teamcity/viewType.html?buildTypeId=ArtifactDepBuildConfig123");
+            artifactDependency.SourceBuildType.ProjectId.Should().Be("ArtifactDepProj123");
+            artifactDependency.SourceBuildType.ProjectName.Should().Be("ArtifactDep Project 123");
         }
 
         [Test]

--- a/FluentTc/Domain/SnapshotDependency.cs
+++ b/FluentTc/Domain/SnapshotDependency.cs
@@ -1,5 +1,7 @@
 namespace FluentTc.Domain
 {
+    using JsonFx.Json;
+
     public class SnapshotDependency
     {
         public override string ToString()
@@ -8,6 +10,12 @@ namespace FluentTc.Domain
         }
 
         public string Id { get; set; }
+
+        public string Type { get; set; }
+
         public Properties Properties { get; set; }
+
+        [JsonName("source-buildType")]
+        public SourceBuildType SourceBuildType { get; set; }
     }
 }

--- a/FluentTc/Domain/SourceBuildType.cs
+++ b/FluentTc/Domain/SourceBuildType.cs
@@ -11,5 +11,7 @@
         public string Name { get; set; }
         public string ProjectName { get; set; }
         public string ProjectId { get; set; }
+        public string Href { get; set; }
+        public string WebUrl { get; set; }
     }
 }


### PR DESCRIPTION
… SourceBuildType properties.

### Issue details

Added SourceBuildType property to SnapshotDependency. Extended set of SourceBuildType properties (href + webUrl). Full set of properties required for Update SnapshotDependency / ArtifactDependency via PUT method.

### Relates to issue
_Use close #XX or connect #XX in order to resolve or link an issue_

### Checklist
- [+] All unit tests passed on build server
- [+] Acceptance test(s) covers new/modified functionality 
- [+] Code coverage is at least the same or higher
- [-] Breaking change in public API

# Example of using new/modified functionality

```C#
var snapshotDependency = buildConfiguration.SnapshotDependencies.SnapshotDependency.Single();
var depConfigId = snapshotDependency.SourceBuildType.Id;
var depConfigName =snapshotDependency.SourceBuildType.Name;
var depConfigHref = snapshotDependency.SourceBuildType.Href;
```
