### PR TITLE
Implementing GetProject() with lambda calls

### DIFF
--- a/FluentTc.Tests/FluentTc.Tests.csproj
+++ b/FluentTc.Tests/FluentTc.Tests.csproj
@@ -137,6 +137,7 @@
     <Compile Include="Locators\TeamCityConfigurationBuilderTests.cs" />
     <Compile Include="Locators\UserHavingBuilderTests.cs" />
     <Compile Include="Locators\VCSRootEntryBuilderTests.cs" />
+    <Compile Include="ProjectRetrievalTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RemoteTcTests.cs" />
     <Compile Include="AgentsRetrieverTests.cs" />

--- a/FluentTc.Tests/ProjectRetrievalTests.cs
+++ b/FluentTc.Tests/ProjectRetrievalTests.cs
@@ -1,0 +1,84 @@
+﻿using System.Collections.Generic;
+using FakeItEasy;
+using FluentTc.Domain;
+using FluentTc.Engine;
+using NUnit.Framework;
+
+namespace FluentTc.Tests
+{
+    [TestFixture]
+    public class ProjectRetrievalTests
+    {
+        [TestCase("FluentTC")]
+        [TestCase("Test 1")]
+        [TestCase("Test%20C")]
+        public void GetProject_ByName(string projectName)
+        {
+            // Arrange
+            var teamCityCaller = CreateTeamCityCaller();
+            new RemoteTc().Connect(_ => _.AsGuest(), teamCityCaller)
+                          .GetProject(project => project.Name(projectName));
+
+            //Expectations
+            var expectedCall = string.Format(@"/app/rest/projects/name:{0}", projectName);
+            A.CallTo(() => teamCityCaller.Get<Project>(expectedCall)).MustHaveHappened();
+        }
+
+        [TestCase("1234")]
+        [TestCase("ABcd")]
+        [TestCase("129@$$jd")]
+        public void GetProject_ById(string projectId)
+        {
+            // Arrange
+            var teamCityCaller = CreateTeamCityCaller();
+            new RemoteTc().Connect(_ => _.AsGuest(), teamCityCaller)
+                          .GetProject(project => project.Id(projectId));
+
+            //Expectations
+            var expectedCall = string.Format(@"/app/rest/projects/id:{0}", projectId);
+            A.CallTo(() => teamCityCaller.Get<Project>(expectedCall)).MustHaveHappened();
+        }
+
+        private static TeamCityCaller CreateTeamCityCaller()
+        {
+            var teamCityCaller = A.Fake<TeamCityCaller>();
+            var projectWrapper = new ProjectWrapper
+            {
+                Project = new List<Project>
+                {
+                    new Project
+                    {
+                        Id = "1234",
+                        Name = "Test 1"
+                    },
+                    new Project
+                    {
+                        Id = "ABcd",
+                        Name = "Test%20C"
+                    },
+                    new Project
+                    {
+                        Id = "129@$$jd",
+                        Name = "FluentTC"
+                    }
+                }
+            };
+            A.CallTo(() => teamCityCaller.GetFormat<User>(A<string>._, A<object[]>._)).CallsBaseMethod();
+            A.CallTo(() => teamCityCaller.GetFormat<UserWrapper>(A<string>._, A<object[]>._)).CallsBaseMethod();
+            A.CallTo(() => teamCityCaller.GetFormat<InvestigationWrapper>(A<string>._, A<object[]>._)).CallsBaseMethod();
+            A.CallTo(() => teamCityCaller.GetFormat<BuildModel>(A<string>._, A<object[]>._)).CallsBaseMethod();
+            A.CallTo(() => teamCityCaller.GetFormat<BuildConfiguration>(A<string>._, A<object[]>._)).CallsBaseMethod();
+            A.CallTo(() => teamCityCaller.GetFormat<ProjectWrapper>(A<string>._, A<object[]>._)).Returns(projectWrapper);
+            A.CallTo(() => teamCityCaller.GetFormat<Project>(A<string>._, A<object[]>._)).CallsBaseMethod();
+            A.CallTo(() => teamCityCaller.GetFormat<BuildTypeWrapper>(A<string>._, A<object[]>._)).CallsBaseMethod();
+            A.CallTo(() => teamCityCaller.GetFormat<BuildWrapper>(A<string>._, A<object[]>._)).CallsBaseMethod();
+            A.CallTo(() => teamCityCaller.GetFormat<BuildWrapper>(A<string>._)).CallsBaseMethod();
+            A.CallTo(() => teamCityCaller.PostFormat(A<object>._, A<string>._, A<string>._, A<object[]>._)).CallsBaseMethod();
+            A.CallTo(() => teamCityCaller.PostFormat<BuildConfiguration>(A<object>._, A<string>._, A<string>._, A<string>._, A<object[]>._)).CallsBaseMethod();
+            A.CallTo(() => teamCityCaller.PostFormat<Project>(A<object>._, A<string>._, A<string>._, A<string>._, A<object[]>._)).CallsBaseMethod();
+            A.CallTo(() => teamCityCaller.PutFormat(A<object>._, A<string>._, A<string>._, A<object[]>._)).CallsBaseMethod();
+            A.CallTo(() => teamCityCaller.DeleteFormat(A<string>._, A<object[]>._)).CallsBaseMethod();
+            return teamCityCaller;
+        }
+    }
+}

--- a/FluentTc/ConnectedTc.cs
+++ b/FluentTc/ConnectedTc.cs
@@ -129,7 +129,18 @@ namespace FluentTc
         void DisableAgent(Action<IAgentHavingBuilder> having);
         void EnableAgent(Action<IAgentHavingBuilder> having);
         void AttachBuildConfigurationToTemplate(Action<IBuildConfigurationHavingBuilder> having, string buildTemplateId);
+        /// <summary>
+        ///     Retrieves a project that has the projectId as an Id.
+        /// </summary>
+        /// <param name="projectId">The expected id for the wanted project.</param>
+        /// <returns>Project</returns>
         Project GetProjectById(string projectId);
+        /// <summary>
+        ///     Retrieves a project that matches having parameter.
+        /// </summary>
+        /// <param name="having">Retrieve project that matches the criteria</param>
+        /// <returns>Project</returns>
+        Project GetProject(Action<IBuildProjectHavingBuilder> having);
         IList<BuildConfiguration> GetBuildConfigurationsRecursively(string projectId);
         IList<Project> GetAllProjects();
         IList<string> DownloadArtifacts(int buildId, string destinationPath);
@@ -404,6 +415,11 @@ namespace FluentTc
         public Project GetProjectById(string projectId)
         {
             return m_ProjectsRetriever.GetProject(projectId);
+        }
+
+        public Project GetProject(Action<IBuildProjectHavingBuilder> having)
+        {
+            return m_ProjectsRetriever.GetProject(having);
         }
 
         public IList<Project> GetProjects(Action<IBuildProjectHavingBuilder> having)

--- a/FluentTc/RemoteTc.cs
+++ b/FluentTc/RemoteTc.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Linq;
-using FluentTc.Domain;
-using FluentTc.Engine;
 using FluentTc.Locators;
 
 namespace FluentTc


### PR DESCRIPTION
### Issue details

Implementation for getting projects based on lambda expressions.

### Relates to issue
#102 

### Checklist
- [ ] All unit tests passed on build server
- [ ] Acceptance test(s) covers new/modified functionality 
- [ ] Code coverage is at least the same or higher
- [ ] Breaking change in public API

# Example of using new/modified functionality

```C#
  var project = new RemoteTc(c=>c.ToHost("HOST").AsGuest())
     .GetProject(project => project.Id("FluentTc") );

  var project = new RemoteTc(c=>c.ToHost("HOST").AsGuest())
     .GetProject(project => project.Name("FluentTc") );
```
