### PR TITLE
Enable VCS Root with SSH Key Authentication

### DIFF
--- a/FluentTc.Tests/AcceptanceTests.cs
+++ b/FluentTc.Tests/AcceptanceTests.cs
@@ -1659,7 +1659,7 @@ namespace FluentTc.Tests
                 .Name("VcsRootName")
                 .ProjectId("ProjectId")
                 .CheckoutSubModule()
-                .UploadedKey("keyName")
+                .TeamcitySshKey("keyName")
                 .Url(new Uri("http://www.gooogle.com"))
                 .UseAlternates()
                 .UserNameStyle(UserNameStyle.AuthorName));

--- a/FluentTc.Tests/AcceptanceTests.cs
+++ b/FluentTc.Tests/AcceptanceTests.cs
@@ -1609,11 +1609,10 @@ namespace FluentTc.Tests
         {
             // Arrange
             var teamCityCaller = CreateTeamCityCaller();
-
             var connectedTc = new RemoteTc().Connect(_ => _.AsGuest(), teamCityCaller);
 
             // Act
-            var vcsRoot = connectedTc.CreateVcsRoot(__ => __
+            connectedTc.CreateVcsRoot(__ => __
                 .AgentCleanFilePolicy(AgentCleanFilePolicy.AllIgnoredUntrackedFiles)
                 .AgentCleanPolicy(AgentCleanPolicy.Always)
                 .AuthMethod(AuthMethod.Anonymous)
@@ -1631,23 +1630,8 @@ namespace FluentTc.Tests
                 .UserNameStyle(UserNameStyle.AuthorName));
 
             // Assert
-            string xmlData = string.Format(
-                @"<vcs-root id=""{0}"" name=""{1}"" vcsName=""{2}""> <project id=""{3}""/> <properties count =""{4}"">",
-                SecurityElement.Escape(vcsRoot.Id),
-                SecurityElement.Escape(vcsRoot.Name),
-                SecurityElement.Escape(vcsRoot.vcsName),
-                SecurityElement.Escape(vcsRoot.Project.Id),
-                vcsRoot.Properties.Property.Count);
-
-            foreach (var property in vcsRoot.Properties.Property)
-            {
-                xmlData += @"<property name=""";
-                xmlData += SecurityElement.Escape(property.Name) + @"""";
-                xmlData += @" value=""" + SecurityElement.Escape(property.Value) + @"""/>";
-            }
-            xmlData += @"</properties>";
-
-            xmlData += @"</vcs-root>";
+            string xmlData =
+                "<vcs-root id=\"VcsRootId\" name=\"VcsRootName\" vcsName=\"jetbrains.git\"> <project id=\"ProjectId\"/> <properties count =\"12\"><property name=\"agentCleanFilePolicy\" value=\"ALL_IGNORED_UNTRACKED_FILES\"/><property name=\"agentCleanPolicy\" value=\"ALWAYS\"/><property name=\"authMethod\" value=\"ANONYMOUS\"/><property name=\"branch\" value=\"refs/head/develop\"/><property name=\"teamcity:branchSpec\" value=\"+:refs/head/feature/*\"/><property name=\"ignoreKnownHosts\" value=\"true\"/><property name=\"secure:password\" value=\"Password\"/><property name=\"submoduleCheckout\" value=\"CHECKOUT\"/><property name=\"url\" value=\"http://www.gooogle.com/\"/><property name=\"useAlternates\" value=\"true\"/><property name=\"username\" value=\"Username\"/><property name=\"userNameStyle\" value=\"AUTHOR_NAME\"/></properties></vcs-root>";
 
             A.CallTo(
                     () =>
@@ -1661,11 +1645,10 @@ namespace FluentTc.Tests
         {
             // Arrange
             var teamCityCaller = CreateTeamCityCaller();
-
             var connectedTc = new RemoteTc().Connect(_ => _.AsGuest(), teamCityCaller);
 
             // Act
-            var vcsRoot = connectedTc.CreateVcsRoot(__ => __
+            connectedTc.CreateVcsRoot(__ => __
                 .AgentCleanFilePolicy(AgentCleanFilePolicy.AllIgnoredUntrackedFiles)
                 .AgentCleanPolicy(AgentCleanPolicy.Always)
                 .AuthMethod(AuthMethod.TeamcitySshKey)
@@ -1682,23 +1665,8 @@ namespace FluentTc.Tests
                 .UserNameStyle(UserNameStyle.AuthorName));
 
             // Assert
-            string xmlData = string.Format(
-                @"<vcs-root id=""{0}"" name=""{1}"" vcsName=""{2}""> <project id=""{3}""/> <properties count =""{4}"">",
-                SecurityElement.Escape(vcsRoot.Id),
-                SecurityElement.Escape(vcsRoot.Name),
-                SecurityElement.Escape(vcsRoot.vcsName),
-                SecurityElement.Escape(vcsRoot.Project.Id),
-                vcsRoot.Properties.Property.Count);
-
-            foreach (var property in vcsRoot.Properties.Property)
-            {
-                xmlData += @"<property name=""";
-                xmlData += SecurityElement.Escape(property.Name) + @"""";
-                xmlData += @" value=""" + SecurityElement.Escape(property.Value) + @"""/>";
-            }
-            xmlData += @"</properties>";
-
-            xmlData += @"</vcs-root>";
+            var xmlData =
+                "<vcs-root id=\"VcsRootId\" name=\"VcsRootName\" vcsName=\"jetbrains.git\"> <project id=\"ProjectId\"/> <properties count =\"11\"><property name=\"agentCleanFilePolicy\" value=\"ALL_IGNORED_UNTRACKED_FILES\"/><property name=\"agentCleanPolicy\" value=\"ALWAYS\"/><property name=\"authMethod\" value=\"TEAMCITY_SSH_KEY\"/><property name=\"branch\" value=\"refs/head/develop\"/><property name=\"teamcity:branchSpec\" value=\"+:refs/head/feature/*\"/><property name=\"ignoreKnownHosts\" value=\"true\"/><property name=\"submoduleCheckout\" value=\"CHECKOUT\"/><property name=\"teamcitySshKey\" value=\"keyName\"/><property name=\"url\" value=\"http://www.gooogle.com/\"/><property name=\"useAlternates\" value=\"true\"/><property name=\"userNameStyle\" value=\"AUTHOR_NAME\"/></properties></vcs-root>";
 
             A.CallTo(
                     () =>

--- a/FluentTc.Tests/Locators/GitVCSRootBuilderTests.cs
+++ b/FluentTc.Tests/Locators/GitVCSRootBuilderTests.cs
@@ -78,7 +78,7 @@ namespace FluentTc.Tests.Locators
             var vcsRootBuilder = new GitVCSRootBuilder();
             vcsRootBuilder
                 .AuthMethod(AuthMethod.TeamcitySshKey)
-                .UploadedKey("keyName");
+                .TeamcitySshKey("keyName");
             var vcsRoot = vcsRootBuilder.GetVCSRoot();
 
             // Assert

--- a/FluentTc.Tests/Locators/GitVCSRootBuilderTests.cs
+++ b/FluentTc.Tests/Locators/GitVCSRootBuilderTests.cs
@@ -38,41 +38,109 @@ namespace FluentTc.Tests.Locators
             vcsRoot.Project.Id.Should().Be("projectId");
             var properties = vcsRoot.Properties.Property;
             properties.FirstOrDefault(
-                p => p.Name == "agentCleanFilePolicy" && 
-                p.Value == "ALL_IGNORED_UNTRACKED_FILES").Should().NotBeNull();
+                p => p.Name == "agentCleanFilePolicy" &&
+                     p.Value == "ALL_IGNORED_UNTRACKED_FILES").Should().NotBeNull();
             properties.FirstOrDefault(
                 p => p.Name == "agentCleanPolicy" &&
-                p.Value == "ALWAYS").Should().NotBeNull();
+                     p.Value == "ALWAYS").Should().NotBeNull();
             properties.FirstOrDefault(
                 p => p.Name == "authMethod" &&
-                p.Value == "ANONYMOUS").Should().NotBeNull();
+                     p.Value == "ANONYMOUS").Should().NotBeNull();
             properties.FirstOrDefault(
                 p => p.Name == "branch" &&
-                p.Value == "branch").Should().NotBeNull();
+                     p.Value == "branch").Should().NotBeNull();
             properties.FirstOrDefault(
                 p => p.Name == "teamcity:branchSpec" &&
-                p.Value == "branchSpec").Should().NotBeNull();
+                     p.Value == "branchSpec").Should().NotBeNull();
             properties.FirstOrDefault(
                 p => p.Name == "submoduleCheckout" &&
-                p.Value == "CHECKOUT").Should().NotBeNull();
+                     p.Value == "CHECKOUT").Should().NotBeNull();
             properties.FirstOrDefault(
                 p => p.Name == "ignoreKnownHosts" &&
-                p.Value == "true").Should().NotBeNull();
+                     p.Value == "true").Should().NotBeNull();
             properties.FirstOrDefault(
                 p => p.Name == "secure:password" &&
-                p.Value == "password").Should().NotBeNull();
+                     p.Value == "password").Should().NotBeNull();
             properties.FirstOrDefault(
                 p => p.Name == "url" &&
-                p.Value == url.ToString()).Should().NotBeNull();
+                     p.Value == url.ToString()).Should().NotBeNull();
             properties.FirstOrDefault(
                 p => p.Name == "useAlternates" &&
-                p.Value == "true").Should().NotBeNull();
+                     p.Value == "true").Should().NotBeNull();
             properties.FirstOrDefault(
                 p => p.Name == "username" &&
-                p.Value == "username").Should().NotBeNull();
+                     p.Value == "username").Should().NotBeNull();
             properties.FirstOrDefault(
                 p => p.Name == "userNameStyle" &&
-                p.Value == "AUTHOR_NAME").Should().NotBeNull();
+                     p.Value == "AUTHOR_NAME").Should().NotBeNull();
+        }
+
+        [Test]
+        public void SimpleCreationSsh()
+        {
+            var vcsRootBuilder = new GitVCSRootBuilder();
+            var url = new Uri("http://www.google.com");
+
+            vcsRootBuilder
+                .AgentCleanFilePolicy(AgentCleanFilePolicy.AllIgnoredUntrackedFiles)
+                .AgentCleanPolicy(AgentCleanPolicy.Always)
+                .AuthMethod(AuthMethod.TeamcitySshKey)
+                .Branch("branch")
+                .BranchSpec("branchSpec")
+                .CheckoutSubModule()
+                .Id("id")
+                .IgnoreKnownHosts()
+                .Name("name")
+                .ProjectId("projectId")
+                .UploadedKey("keyName")
+                .Url(url)
+                .UseAlternates()
+                .UserNameStyle(UserNameStyle.AuthorName);
+
+            var vcsRoot = vcsRootBuilder.GetVCSRoot();
+            vcsRoot.Id.Should().Be("id");
+            vcsRoot.Name.Should().Be("name");
+            vcsRoot.Project.Id.Should().Be("projectId");
+            var properties = vcsRoot.Properties.Property;
+            properties.FirstOrDefault(
+                p => p.Name == "agentCleanFilePolicy" &&
+                     p.Value == "ALL_IGNORED_UNTRACKED_FILES").Should().NotBeNull();
+            properties.FirstOrDefault(
+                p => p.Name == "agentCleanPolicy" &&
+                     p.Value == "ALWAYS").Should().NotBeNull();
+            properties.FirstOrDefault(
+                p => p.Name == "authMethod" &&
+                     p.Value == "ANONYMOUS").Should().BeNull();
+            properties.FirstOrDefault(
+                p => p.Name == "authMethod" &&
+                     p.Value == "TEAMCITY_SSH_KEY").Should().NotBeNull();
+            properties.FirstOrDefault(
+                p => p.Name == "branch" &&
+                     p.Value == "branch").Should().NotBeNull();
+            properties.FirstOrDefault(
+                p => p.Name == "teamcity:branchSpec" &&
+                     p.Value == "branchSpec").Should().NotBeNull();
+            properties.FirstOrDefault(
+                p => p.Name == "submoduleCheckout" &&
+                     p.Value == "CHECKOUT").Should().NotBeNull();
+            properties.FirstOrDefault(
+                p => p.Name == "ignoreKnownHosts" &&
+                     p.Value == "true").Should().NotBeNull();
+            properties.FirstOrDefault(
+                p => p.Name == "secure:password" &&
+                     p.Value == "password").Should().BeNull();
+            properties.FirstOrDefault(
+                p => p.Name == "url" &&
+                     p.Value == url.ToString()).Should().NotBeNull();
+            properties.FirstOrDefault(
+                p => p.Name == "useAlternates" &&
+                     p.Value == "true").Should().NotBeNull();
+            properties.FirstOrDefault(
+                p => p.Name == "teamcitySshKey" &&
+                     p.Value == "keyName").Should().NotBeNull();
+            properties.FirstOrDefault(
+                p => p.Name == "userNameStyle" &&
+                     p.Value == "AUTHOR_NAME").Should().NotBeNull();
         }
     }
 }

--- a/FluentTc.Tests/Locators/GitVCSRootBuilderTests.cs
+++ b/FluentTc.Tests/Locators/GitVCSRootBuilderTests.cs
@@ -2,7 +2,6 @@
 using FluentTc.Locators;
 using NUnit.Framework;
 using System;
-using System.Linq;
 
 namespace FluentTc.Tests.Locators
 {
@@ -37,110 +36,55 @@ namespace FluentTc.Tests.Locators
             vcsRoot.Name.Should().Be("name");
             vcsRoot.Project.Id.Should().Be("projectId");
             var properties = vcsRoot.Properties.Property;
-            properties.FirstOrDefault(
-                p => p.Name == "agentCleanFilePolicy" &&
-                     p.Value == "ALL_IGNORED_UNTRACKED_FILES").Should().NotBeNull();
-            properties.FirstOrDefault(
+            properties.Should().ContainSingle(
                 p => p.Name == "agentCleanPolicy" &&
-                     p.Value == "ALWAYS").Should().NotBeNull();
-            properties.FirstOrDefault(
+                     p.Value == "ALWAYS");
+            properties.Should().ContainSingle(
                 p => p.Name == "authMethod" &&
-                     p.Value == "ANONYMOUS").Should().NotBeNull();
-            properties.FirstOrDefault(
+                     p.Value == "ANONYMOUS");
+            properties.Should().ContainSingle(
                 p => p.Name == "branch" &&
-                     p.Value == "branch").Should().NotBeNull();
-            properties.FirstOrDefault(
+                     p.Value == "branch");
+            properties.Should().ContainSingle(
                 p => p.Name == "teamcity:branchSpec" &&
-                     p.Value == "branchSpec").Should().NotBeNull();
-            properties.FirstOrDefault(
+                     p.Value == "branchSpec");
+            properties.Should().ContainSingle(
                 p => p.Name == "submoduleCheckout" &&
-                     p.Value == "CHECKOUT").Should().NotBeNull();
-            properties.FirstOrDefault(
+                     p.Value == "CHECKOUT");
+            properties.Should().ContainSingle(
                 p => p.Name == "ignoreKnownHosts" &&
-                     p.Value == "true").Should().NotBeNull();
-            properties.FirstOrDefault(
+                     p.Value == "true");
+            properties.Should().ContainSingle(
                 p => p.Name == "secure:password" &&
-                     p.Value == "password").Should().NotBeNull();
-            properties.FirstOrDefault(
+                     p.Value == "password");
+            properties.Should().ContainSingle(
                 p => p.Name == "url" &&
-                     p.Value == url.ToString()).Should().NotBeNull();
-            properties.FirstOrDefault(
+                     p.Value == url.ToString());
+            properties.Should().ContainSingle(
                 p => p.Name == "useAlternates" &&
-                     p.Value == "true").Should().NotBeNull();
-            properties.FirstOrDefault(
+                     p.Value == "true");
+            properties.Should().ContainSingle(
                 p => p.Name == "username" &&
-                     p.Value == "username").Should().NotBeNull();
-            properties.FirstOrDefault(
+                     p.Value == "username");
+            properties.Should().ContainSingle(
                 p => p.Name == "userNameStyle" &&
-                     p.Value == "AUTHOR_NAME").Should().NotBeNull();
+                     p.Value == "AUTHOR_NAME");
         }
 
         [Test]
-        public void SimpleCreationSsh()
+        public void GetVCSRoot_SshKey_SshKeyCreated()
         {
+            // Act
             var vcsRootBuilder = new GitVCSRootBuilder();
-            var url = new Uri("http://www.google.com");
-
             vcsRootBuilder
-                .AgentCleanFilePolicy(AgentCleanFilePolicy.AllIgnoredUntrackedFiles)
-                .AgentCleanPolicy(AgentCleanPolicy.Always)
                 .AuthMethod(AuthMethod.TeamcitySshKey)
-                .Branch("branch")
-                .BranchSpec("branchSpec")
-                .CheckoutSubModule()
-                .Id("id")
-                .IgnoreKnownHosts()
-                .Name("name")
-                .ProjectId("projectId")
-                .UploadedKey("keyName")
-                .Url(url)
-                .UseAlternates()
-                .UserNameStyle(UserNameStyle.AuthorName);
-
+                .UploadedKey("keyName");
             var vcsRoot = vcsRootBuilder.GetVCSRoot();
-            vcsRoot.Id.Should().Be("id");
-            vcsRoot.Name.Should().Be("name");
-            vcsRoot.Project.Id.Should().Be("projectId");
-            var properties = vcsRoot.Properties.Property;
-            properties.FirstOrDefault(
-                p => p.Name == "agentCleanFilePolicy" &&
-                     p.Value == "ALL_IGNORED_UNTRACKED_FILES").Should().NotBeNull();
-            properties.FirstOrDefault(
-                p => p.Name == "agentCleanPolicy" &&
-                     p.Value == "ALWAYS").Should().NotBeNull();
-            properties.FirstOrDefault(
-                p => p.Name == "authMethod" &&
-                     p.Value == "ANONYMOUS").Should().BeNull();
-            properties.FirstOrDefault(
-                p => p.Name == "authMethod" &&
-                     p.Value == "TEAMCITY_SSH_KEY").Should().NotBeNull();
-            properties.FirstOrDefault(
-                p => p.Name == "branch" &&
-                     p.Value == "branch").Should().NotBeNull();
-            properties.FirstOrDefault(
-                p => p.Name == "teamcity:branchSpec" &&
-                     p.Value == "branchSpec").Should().NotBeNull();
-            properties.FirstOrDefault(
-                p => p.Name == "submoduleCheckout" &&
-                     p.Value == "CHECKOUT").Should().NotBeNull();
-            properties.FirstOrDefault(
-                p => p.Name == "ignoreKnownHosts" &&
-                     p.Value == "true").Should().NotBeNull();
-            properties.FirstOrDefault(
-                p => p.Name == "secure:password" &&
-                     p.Value == "password").Should().BeNull();
-            properties.FirstOrDefault(
-                p => p.Name == "url" &&
-                     p.Value == url.ToString()).Should().NotBeNull();
-            properties.FirstOrDefault(
-                p => p.Name == "useAlternates" &&
-                     p.Value == "true").Should().NotBeNull();
-            properties.FirstOrDefault(
-                p => p.Name == "teamcitySshKey" &&
-                     p.Value == "keyName").Should().NotBeNull();
-            properties.FirstOrDefault(
-                p => p.Name == "userNameStyle" &&
-                     p.Value == "AUTHOR_NAME").Should().NotBeNull();
+
+            // Assert
+            vcsRoot.Properties.Property.Should()
+                .ContainSingle(p => p.Name == "authMethod" && p.Value == "TEAMCITY_SSH_KEY");
+            vcsRoot.Properties.Property.Should().ContainSingle(p => p.Name == "teamcitySshKey" && p.Value == "keyName");
         }
     }
 }

--- a/FluentTc/Locators/GitVCSRootBuilder.cs
+++ b/FluentTc/Locators/GitVCSRootBuilder.cs
@@ -23,7 +23,8 @@ namespace FluentTc.Locators
     public enum AuthMethod
     {
         Anonymous,
-        Password
+        Password,
+        TeamcitySshKey
     }
 
     public enum UserNameStyle
@@ -43,6 +44,7 @@ namespace FluentTc.Locators
         IGitVCSRootBuilder AgentCleanPolicy(AgentCleanPolicy value);
 
         IGitVCSRootBuilder AuthMethod(AuthMethod value);
+        IGitVCSRootBuilder UploadedKey(string value);
 
         IGitVCSRootBuilder Branch(string value);
         IGitVCSRootBuilder IgnoreKnownHosts();
@@ -122,6 +124,12 @@ namespace FluentTc.Locators
         public IGitVCSRootBuilder AuthMethod(AuthMethod value)
         {
             AppendProperty(value);
+            return this;
+        }
+
+        public IGitVCSRootBuilder UploadedKey(string value)
+        {
+            AppendProperty("teamcitySshKey", value);
             return this;
         }
 

--- a/FluentTc/Locators/GitVCSRootBuilder.cs
+++ b/FluentTc/Locators/GitVCSRootBuilder.cs
@@ -44,7 +44,7 @@ namespace FluentTc.Locators
         IGitVCSRootBuilder AgentCleanPolicy(AgentCleanPolicy value);
 
         IGitVCSRootBuilder AuthMethod(AuthMethod value);
-        IGitVCSRootBuilder UploadedKey(string value);
+        IGitVCSRootBuilder TeamcitySshKey(string value);
 
         IGitVCSRootBuilder Branch(string value);
         IGitVCSRootBuilder IgnoreKnownHosts();
@@ -127,7 +127,7 @@ namespace FluentTc.Locators
             return this;
         }
 
-        public IGitVCSRootBuilder UploadedKey(string value)
+        public IGitVCSRootBuilder TeamcitySshKey(string value)
         {
             AppendProperty("teamcitySshKey", value);
             return this;


### PR DESCRIPTION
### Issue details

I want to use FluentTC to create VCS Roots with uploaded SSH Key

### Relates to issue
close #110 

### Checklist
- [ ] All unit tests passed on build server
- [ ] Acceptance test(s) covers new/modified functionality 
- [ ] Code coverage is at least the same or higher
- [ ] Breaking change in public API

# Example of using new/modified functionality

```C#
var vcsRoot = connectedTc.CreateVcsRoot(__ => __
                .AgentCleanFilePolicy(AgentCleanFilePolicy.AllIgnoredUntrackedFiles)
                .AgentCleanPolicy(AgentCleanPolicy.Always)
                .AuthMethod(AuthMethod.TeamcitySshKey)
                .Branch("refs/head/develop")
                .BranchSpec("+:refs/head/feature/*")
                .Id("VcsRootId")
                .IgnoreKnownHosts()
                .Name("VcsRootName")
                .ProjectId("ProjectId")
                .CheckoutSubModule()
                .UploadedKey("keyName")
                .Url(new Uri("http://www.gooogle.com"))
                .UseAlternates()
                .UserNameStyle(UserNameStyle.AuthorName));
```
