### PR TITLE
Publish build artifacts as part of the build

### DIFF
--- a/FluentTc.Tests/LocalTcTests.cs
+++ b/FluentTc.Tests/LocalTcTests.cs
@@ -183,5 +183,39 @@ namespace FluentTc.Tests
             // Assert
             isPersonal.Should().BeFalse();
         }
+
+        [Test]
+        public void PublishArtifact_FileName_Published()
+        {
+            // Arrange
+            var teamCityWriterFactory = A.Fake<ITeamCityWriterFactory>();
+            var teamCityWriter = A.Fake<ITeamCityWriter>();
+            A.CallTo(() => teamCityWriterFactory.CreateTeamCityWriter()).Returns(teamCityWriter);
+
+            var localTc = new LocalTc(A.Fake<IBuildParameters>(), teamCityWriterFactory);
+
+            // Act
+            localTc.PublishArtifact("file.txt");
+
+            // Assert
+            A.CallTo(()=>teamCityWriter.PublishArtifact("file.txt")).MustHaveHappened();
+        }
+
+        [Test]
+        public void PublishArtifact_FileNameAndTarget_Published()
+        {
+            // Arrange
+            var teamCityWriterFactory = A.Fake<ITeamCityWriterFactory>();
+            var teamCityWriter = A.Fake<ITeamCityWriter>();
+            A.CallTo(() => teamCityWriterFactory.CreateTeamCityWriter()).Returns(teamCityWriter);
+
+            var localTc = new LocalTc(A.Fake<IBuildParameters>(), teamCityWriterFactory);
+
+            // Act
+            localTc.PublishArtifact("file.txt", "dir");
+
+            // Assert
+            A.CallTo(()=>teamCityWriter.PublishArtifact("file.txt => dir")).MustHaveHappened();
+        }
     }
 }

--- a/FluentTc/LocalTc.cs
+++ b/FluentTc/LocalTc.cs
@@ -31,6 +31,31 @@ namespace FluentTc
         bool IsTeamCityMode { get; }
         bool IsPersonal { get; }
         void SetBuildParameter(string parameterName, string parameterValue);
+
+        /// <summary>
+        /// Attaches new artifact publishing rules as described in
+        /// http://confluence.jetbrains.net/display/TCD7/Build+Artifact
+        /// </summary>
+        /// <param name="fileDirectoryName">
+        /// Filename to publish. The file name should be relative to the build checkout directory.
+        /// Directory name to publish all the files and subdirectories within the directory specified. The directory name should be a path relative to the build checkout directory. The files will be published preserving the directories structure under the directory specified (the directory itself will not be included).
+        /// </param>
+        void PublishArtifact(string fileDirectoryName);
+
+        /// <summary>
+        /// Attaches new artifact publishing rules as described in
+        /// http://confluence.jetbrains.net/display/TCD7/Build+Artifact
+        /// </summary>
+        /// <param name="fileDirectoryName">
+        /// Filename to publish. The file name should be relative to the build checkout directory.
+        /// Directory name to publish all the files and subdirectories within the directory specified. The directory name should be a path relative to the build checkout directory. The files will be published preserving the directories structure under the directory specified (the directory itself will not be included).
+        /// </param>
+        /// <param name="targetDirectoryArchive">
+        /// Target directory - the directory in the resulting build's artifacts that will contain the files determined by the left part of the pattern.
+        /// Target archive - the path to the archive to be created by TeamCity by packing build artifacts.
+        /// TeamCity treats <paramref name="targetDirectoryArchive"/> as archive whenever it ends with a supported archive extension, i.e. .zip, .jar, .tar.gz, or .tgz.
+        /// </param>
+        void PublishArtifact(string fileDirectoryName, string targetDirectoryArchive);
     }
 
     public class LocalTc : ILocalTc
@@ -172,6 +197,37 @@ namespace FluentTc
         public bool IsPersonal
         {
             get { return m_BuildParameters.IsPersonal; }
+        }
+
+        /// <summary>
+        /// Attaches new artifact publishing rules as described in
+        /// http://confluence.jetbrains.net/display/TCD7/Build+Artifact
+        /// </summary>
+        /// <param name="fileDirectoryName">
+        /// Filename to publish. The file name should be relative to the build checkout directory.
+        /// Directory name to publish all the files and subdirectories within the directory specified. The directory name should be a path relative to the build checkout directory. The files will be published preserving the directories structure under the directory specified (the directory itself will not be included).
+        /// </param>
+        public void PublishArtifact(string fileDirectoryName)
+        {
+            m_TeamCityWriter.PublishArtifact(fileDirectoryName);
+        }
+
+        /// <summary>
+        /// Attaches new artifact publishing rules as described in
+        /// http://confluence.jetbrains.net/display/TCD7/Build+Artifact
+        /// </summary>
+        /// <param name="fileDirectoryName">
+        /// Filename to publish. The file name should be relative to the build checkout directory.
+        /// Directory name to publish all the files and subdirectories within the directory specified. The directory name should be a path relative to the build checkout directory. The files will be published preserving the directories structure under the directory specified (the directory itself will not be included).
+        /// </param>
+        /// <param name="targetDirectoryArchive">
+        /// Target directory - the directory in the resulting build's artifacts that will contain the files determined by the left part of the pattern.
+        /// Target archive - the path to the archive to be created by TeamCity by packing build artifacts.
+        /// TeamCity treats <paramref name="targetDirectoryArchive"/> as archive whenever it ends with a supported archive extension, i.e. .zip, .jar, .tar.gz, or .tgz.
+        /// </param>
+        public void PublishArtifact(string fileDirectoryName, string targetDirectoryArchive)
+        {
+            m_TeamCityWriter.PublishArtifact($"{fileDirectoryName} => {targetDirectoryArchive}");
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -7,13 +7,16 @@ Integrate with TeamCity fluently
 Get TeamCity builds with branches, status, start and finish date and paging
 ```C#
 IList<IBuild> builds =
-    new RemoteTc().Connect(h => h.ToHost("teamcity.codebetter.com").AsGuest())
+    new RemoteTc()
+        .Connect(connect => connect
+            .ToHost("teamcity.jetbrains.com")
+            .AsGuest())
         .GetBuilds(
             having => having
                 .BuildConfiguration(
                     buildConfiguration => buildConfiguration
-                        .Id("FluentTc_FluentTcDevelop"))
-                .Branch(r => r.Branched()),
+                        .Id("FluentTc"))
+                .Branch(branch => branch.Branched()),
             include => include
                 .IncludeStatusText()
                 .IncludeStartDate()
@@ -25,9 +28,12 @@ IList<IBuild> builds =
 
 Run custom build
 ```C#
-IBuild build = new RemoteTc().Connect(h => h.ToHost("teamcity.codebetter.com").AsGuest())
+IBuild build = new RemoteTc()
+    .Connect(connect => connect
+        .ToHost("teamcity.jetbrains.com")
+        .AsGuest())
     .RunBuildConfiguration(
-         buildConfiguration => buildConfiguration.Id("bt2"), 
+         buildConfiguration => buildConfiguration.Id("FluentTc"), 
          agent => agent.Name("Agent1"),
          parameters => parameters
                      .Parameter("param1", "value1")

--- a/README.md
+++ b/README.md
@@ -8,12 +8,19 @@ Get TeamCity builds with branches, status, start and finish date and paging
 ```C#
 IList<IBuild> builds =
     new RemoteTc().Connect(h => h.ToHost("teamcity.codebetter.com").AsGuest())
-        .GetBuilds(b =>
-            b.BuildConfiguration(c =>
-                c.Id("FluentTc_FluentTcDevelop"))
+        .GetBuilds(
+            having => having
+                .BuildConfiguration(
+                    buildConfiguration => buildConfiguration
+                        .Id("FluentTc_FluentTcDevelop"))
                 .Branch(r => r.Branched()),
-            i => i.IncludeStatusText().IncludeStartDate().IncludeFinishDate(), 
-            p => p.Start(30).Count(10));
+            include => include
+                .IncludeStatusText()
+                .IncludeStartDate()
+                .IncludeFinishDate(), 
+            paging => paging
+                .Start(30)
+                .Count(10));
 ```
 
 Run custom build
@@ -25,13 +32,13 @@ IBuild build = new RemoteTc().Connect(h => h.ToHost("teamcity.codebetter.com").A
          parameters => parameters
                      .Parameter("param1", "value1")
                      .Parameter("param2", "value2"),
-         custom => custom.OnBranch("develop")
+         options => options.OnBranch("develop")
                     .WithComment("personal build on develop")
                     .AsPersonal()
                     .QueueAtTop()
                     .RebuildAllDependencies()
-                    .WithCleanSources().
-                    OnChange(change => change.Id(123456)));
+                    .WithCleanSources()
+                    .OnChange(change => change.Id(123456)));
 ```
 
 Interact with TeamCity from within a build step without authentication
@@ -66,15 +73,14 @@ localTc.ChangeBuildStatus(BuildStatus.Success);
 
 # Download
 
-The easiest way to get __FluentTc__ is through Nuget
-Manage Nuget packages or from Nuget Package Manager Console:
+The easiest way to get __FluentTc__ is through Nuget: Visual Studio -> Manage Nuget packages or from Nuget Package Manager Console:
 ```PS
 PM> install-package FluentTc
 ```
 
 # Get Involved
 * For reporting bugs, create an issue on [Github issues](https://github.com/QualiSystems/FluentTc/issues)
-* For contribution fork and submit change via Pull Request 
+* For contribution fork and submit a change via Pull Request 
 
 ## Versioning
 FluentTc adheres to [Semantic Versioning 2.0.0](http://semver.org/), basically means that there are no breaking changes unless the version is 0.x or major version is promoted. 
@@ -83,6 +89,6 @@ FluentTc adheres to [Semantic Versioning 2.0.0](http://semver.org/), basically m
 FluentTc is released under [Apache License 2.0](https://github.com/QualiSystems/FluentTc/blob/master/LICENSE)
 
 ## Credits
-This project would not be possible with the support of [contributors](https://github.com/QualiSystems/FluentTc/graphs/contributors)
+FluentTc project keeps growing with the support of growing comminity of [contributors](https://github.com/QualiSystems/FluentTc/graphs/contributors)
 
 

--- a/README.md
+++ b/README.md
@@ -1,22 +1,10 @@
-[![build status](http://teamcity.codebetter.com/app/rest/builds/buildType:id:FluentTc/statusIcon)](http://teamcity.codebetter.com/viewType.html?buildTypeId=FluentTc&guest=1) [![code coverage](https://img.shields.io/teamcity/coverage/FluentTc.svg)](http://teamcity.codebetter.com/viewType.html?buildTypeId=FluentTc&guest=1) [![NuGet version](https://badge.fury.io/nu/FluentTc.svg)](https://badge.fury.io/nu/FluentTc)  [![Chat on gitter](https://img.shields.io/gitter/room/QualiSystems/FluentTc.svg)](https://gitter.im/QualiSystems/FluentTc) [![Stories in Ready](https://badge.waffle.io/QualiSystems/FluentTc.png?label=ready&title=Ready)](https://waffle.io/QualiSystems/FluentTc)
+[![build status](http://teamcity.codebetter.com/app/rest/builds/buildType:id:FluentTc/statusIcon)](http://teamcity.codebetter.com/viewType.html?buildTypeId=FluentTc&guest=1) [![code coverage](https://img.shields.io/teamcity/coverage/FluentTc.svg)](http://teamcity.codebetter.com/viewType.html?buildTypeId=FluentTc&guest=1) [![NuGet version](https://badge.fury.io/nu/FluentTc.svg)](https://badge.fury.io/nu/FluentTc)  [![Stories in Ready](https://badge.waffle.io/QualiSystems/FluentTc.png?label=ready&title=Ready)](https://waffle.io/QualiSystems/FluentTc)
 
 # FluentTc 
-Easy-to-use, readable and comprehensive library for consuming TeamCity REST API. Written using real scenarios in mind, enables variuos range of queries and operation on TeamCity
+Integrate with TeamCity fluently
 
-# Getting started 
-
-Install __FluentTc__ nuget package from from Manage Nuget packages
-
-Or from Nuget Package Manager Console:
-```PS
-install-package FluentTc
-```
-
-# Example 
-
-Connects to TeamCity using guest account and retrieves builds from the [FluentTc](http://teamcity.codebetter.com/viewType.html?buildTypeId=FluentTc_FluentTcDevelop) build configuration with all its branches, 
-with additional build properties, such as StatusText, StartDate and FinishDate; with paging taking 10 builds starting from the 30th build.
-
+# Getting Started
+Get TeamCity builds with branches, status, start and finish date and paging
 ```C#
 IList<IBuild> builds =
     new RemoteTc().Connect(h => h.ToHost("teamcity.codebetter.com").AsGuest())
@@ -28,22 +16,73 @@ IList<IBuild> builds =
             p => p.Start(30).Count(10));
 ```
 
-For more examples and documentation read the [Wiki](https://github.com/QualiSystems/FluentTc/wiki)
+Run custom build
+```C#
+IBuild build = new RemoteTc().Connect(h => h.ToHost("teamcity.codebetter.com").AsGuest())
+    .RunBuildConfiguration(
+         buildConfiguration => buildConfiguration.Id("bt2"), 
+         agent => agent.Name("Agent1"),
+         parameters => parameters
+                     .Parameter("param1", "value1")
+                     .Parameter("param2", "value2"),
+         custom => custom.OnBranch("develop")
+                    .WithComment("personal build on develop")
+                    .AsPersonal()
+                    .QueueAtTop()
+                    .RebuildAllDependencies()
+                    .WithCleanSources().
+                    OnChange(change => change.Id(123456)));
+```
 
-## Contributors
-This project would not be possible with the support of [contributors](CONTRIBUTORS.md)
+Interact with TeamCity from within a build step without authentication
+```C#
+ILocalTc localTc = new LocalTc();
+
+// Gets the current checkout directory
+string agentWorkDir = localTc.TeamcityBuildCheckoutDir;
+
+// Gets the current parameter value 
+int param1 = localTc.GetBuildParameter<int>("param1");
+
+// Sets parameter value of the current build
+localTc.SetBuildParameter("parameter.name", "value1");
+
+// Gets list of files changed in the current build
+IList<IChangedFile> changedFiles = localTc.ChangedFiles;
+
+// Determines whether the build is personal
+bool isPersonal = localTc.IsPersonal;
+
+// Change status of the current build 
+localTc.ChangeBuildStatus(BuildStatus.Success);
+```
+
+# Dive In
+
+* For more examples and documentation read the [Wiki](https://github.com/QualiSystems/FluentTc/wiki)
+
+* For questions and discussions chat on Gitter:  [![Chat on gitter](https://img.shields.io/gitter/room/QualiSystems/FluentTc.svg)](https://gitter.im/QualiSystems/FluentTc)
+
+
+# Download
+
+The easiest way to get __FluentTc__ is through Nuget
+Manage Nuget packages or from Nuget Package Manager Console:
+```PS
+PM> install-package FluentTc
+```
+
+# Get Involved
+* For reporting bugs, create an issue on [Github issues](https://github.com/QualiSystems/FluentTc/issues)
+* For contribution read 
 
 ## Versioning
 FluentTc adheres to [Semantic Versioning 2.0.0](http://semver.org/), basically means that there are no breaking changes unless the version is 0.x or major version is promoted. 
 
-## Project State
-The project is stable and works in production in a few organizations. It has a growing community of users and contributors.
-Although we are happy with its current state, we'd like to hear what you think. We are asking to spend a few minutes and fill this survey:
-[FluentTc survey](http://goo.gl/forms/42U7MvVFStoieQaB3)
-
 ## License
-[Apache License 2.0](https://github.com/QualiSystems/FluentTc/blob/master/LICENSE)
+FluentTc is released under [Apache License 2.0](https://github.com/QualiSystems/FluentTc/blob/master/LICENSE)
 
 ## Credits
-[![Continuous Integration powered by TeamCity and CodeBetter](https://resources.jetbrains.com/assets/banners/jetbrains-com/Codebetter.png)](http://codebetter.com/codebetter-ci/)
+This project would not be possible with the support of [contributors](https://github.com/QualiSystems/FluentTc/graphs/contributors)
+
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ PM> install-package FluentTc
 
 # Get Involved
 * For reporting bugs, create an issue on [Github issues](https://github.com/QualiSystems/FluentTc/issues)
-* For contribution read 
+* For contribution fork and submit change via Pull Request 
 
 ## Versioning
 FluentTc adheres to [Semantic Versioning 2.0.0](http://semver.org/), basically means that there are no breaking changes unless the version is 0.x or major version is promoted. 


### PR DESCRIPTION
### Issue details

https://github.com/QualiSystems/FluentTc/issues/28

### Relates to issue
Connect #28 

### Checklist
- [X] All unit tests passed on build server
- [X] Acceptance test(s) covers new/modified functionality 
- [X] Code coverage is at least the same or higher
- [ ] Breaking change in public API

# Example of using new/modified functionality

```C#
// To publish a single file
new LocalTc().PublishArtifacts("some.zip")

// To publish a directory
new LocalTc().PublishArtifacts("dir")

// To publish files into a target directory
new LocalTc().PublishArtifacts("file.*", "target_dir")

// To publish files into a target archive
new LocalTc().PublishArtifacts("file.*", "target_archive.zip")

```
